### PR TITLE
fix: fixed no affiliation records showing before load

### DIFF
--- a/business-registry-dashboard/app/stores/affiliations.ts
+++ b/business-registry-dashboard/app/stores/affiliations.ts
@@ -17,7 +17,7 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
       type: '',
       status: ''
     },
-    loading: false,
+    loading: true,
     results: [] as Business[],
     count: 0
   })

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
Ticket #: https://github.com/bcgov/entity/issues/24979

Fixed no affiliation records showing on initial page load which is wrong since it's showing before the affiliations are actually loaded.