### PR TITLE
fix: existing businesses route to business dashboard (removed FF check)

### DIFF
--- a/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
+++ b/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
@@ -256,13 +256,11 @@ async function redirect (item: Business) {
     } else {
       affNav.goToNameRequest(item.nameRequest)
     }
-  } else if (isModernizedEntity(item)) { // handle modernized entity
-    await affStore.removeAcceptedAffiliationInvitations(item)
-    affNav.goToDashboard(item.businessIdentifier)
   } else if (isSocieties(item)) {
     affNav.goToSocieties()
   } else {
-    affNav.goToCorpOnline()
+    await affStore.removeAcceptedAffiliationInvitations(item)
+    affNav.goToDashboard(item.businessIdentifier)
   }
 }
 

--- a/business-registry-dashboard/app/composables/useAffiliationNavigation.ts
+++ b/business-registry-dashboard/app/composables/useAffiliationNavigation.ts
@@ -124,8 +124,8 @@ export function useAffiliationNavigation () {
       return false
     }
 
-    // check for business
-    return !isModernizedEntity(item)
+    // existing businesses will route to Business Dashboard -- don't check FF
+    return false
   }
 
   return {

--- a/business-registry-dashboard/app/composables/useAffiliationNavigation.ts
+++ b/business-registry-dashboard/app/composables/useAffiliationNavigation.ts
@@ -124,7 +124,7 @@ export function useAffiliationNavigation () {
       return false
     }
 
-    // existing businesses will route to Business Dashboard -- don't check FF
+    // existing businesses will route to Business Dashboard -- don't show external icon
     return false
   }
 

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/25076

NRs for entity types not in the FF redirect to COLIN; left as is.
Existing businesses route now to Business Dashboard -- don't check FF.

Basically:
If type is NR, we are checking the `ia-supported-entities-brd` FF. If the FF doesn't support the type, redirect to COLIN.

For existing businesses though, we no more check the FF. We will ALWAYS go to the business dashboard with that business.