### PR TITLE
fix: fix infinite redirect loop in TEST and PROD

### DIFF
--- a/business-registry-dashboard/app/layouts/dashboard.vue
+++ b/business-registry-dashboard/app/layouts/dashboard.vue
@@ -16,9 +16,12 @@ setBreadcrumbs([
   { label: accountStore.isStaffOrSbcStaff ? t('page.home.h1Staff') : t('page.home.h1') }
 ])
 
-onMounted(() => {
+onMounted(async () => {
+  // Wait for next tick to ensure Keycloak has initialized
+  await nextTick()
+
   // Redirect unauthenticated users to login page with current URL as redirect target
-  if (!isAuthenticated.value) {
+  if (isAuthenticated.value === false) { // explicitly check for false
     const registryHomeURL = useRuntimeConfig().public.registryHomeURL
     const redirectUrl = encodeURIComponent(window.location.href)
     window.location.href = `${registryHomeURL}/login/?return=${redirectUrl}`

--- a/business-registry-dashboard/app/layouts/dashboard.vue
+++ b/business-registry-dashboard/app/layouts/dashboard.vue
@@ -21,7 +21,7 @@ onMounted(async () => {
   await nextTick()
 
   // Redirect unauthenticated users to login page with current URL as redirect target
-  if (isAuthenticated.value === false) { // explicitly check for false
+  if (isAuthenticated.value !== true) { // explicitly check for false
     const registryHomeURL = useRuntimeConfig().public.registryHomeURL
     const redirectUrl = encodeURIComponent(window.location.href)
     window.location.href = `${registryHomeURL}/login/?return=${redirectUrl}`

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/25148

This is an ATTEMPT. I can't recreate this issue in neither local nor DEV. It's only in TEST and PROD. I'm pretty sure the issue is:
The page is loading before the keycloak/authentication check is done. I'm hoping my fix here fixes it.

To see what's exactly happening, just try to go to https://business-registry-test.web.app/en-CA