### PR TITLE
fix: fixed the "you should use slots with <ContentRenderer>" error

### DIFF
--- a/business-registry-dashboard/app/components/HelpTextSection.vue
+++ b/business-registry-dashboard/app/components/HelpTextSection.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { UInput } from '#components'
-const { locale } = useI18n()
 const showHelpText = ref(false)
 const showHelpTextBtnRef = ref<InstanceType<typeof UInput> | null>(null)
 
@@ -11,16 +10,6 @@ const toggleHelpText = () => {
     showHelpTextBtnRef.value?.$el.scrollIntoView({ block: 'center', behaviour: 'smooth' })
   }
 }
-
-const { data: helpText } = await useAsyncData('start-manage-business-help-text-' + locale.value, () => {
-  return queryContent()
-    .where({ _locale: locale.value, _path: { $contains: 'start-manage-business-help-text' } })
-    .findOne()
-})
-
-onMounted(() => {
-  console.log('helpText', helpText)
-})
 </script>
 <template>
   <UButton
@@ -45,7 +34,100 @@ onMounted(() => {
       '-mb-0 max-h-[10000px] py-8 opacity-100': showHelpText,
     }"
   >
-    <ContentRenderer :value="helpText" class="prose prose-bcGov prose-h3:text-center prose-p:my-8 prose-ol:space-y-10 max-w-bcGovLg" />
+    <div class="prose prose-bcGov prose-h3:text-center prose-p:my-8 prose-ol:space-y-10 max-w-bcGovLg">
+      <h3>{{ $t('startManageBusinessHelp.heading') }}</h3>
+      <p>{{ $t('startManageBusinessHelp.intro') }}</p>
+      <ol>
+        <!-- Step 1 -->
+        <li>
+          <div class="font-semibold text-gray-900">
+            {{ $t('startManageBusinessHelp.steps.businessType.heading') }}
+          </div>
+          <ul>
+            <li>
+              {{ $t('startManageBusinessHelp.steps.businessType.content1') }}
+              <a
+                href="https://entity-selection-prod.apps.silver.devops.gov.bc.ca/"
+                target="_blank"
+                class="text-blue-500 underline"
+              >
+                {{ $t('startManageBusinessHelp.steps.businessType.wizardLink') }}
+              </a>
+            </li>
+            <li>{{ $t('startManageBusinessHelp.steps.businessType.content2') }}</li>
+            <li>{{ $t('startManageBusinessHelp.steps.businessType.content3') }}</li>
+          </ul>
+        </li>
+
+        <!-- Step 2 -->
+        <li>
+          <div class="font-semibold text-gray-900">
+            {{ $t('startManageBusinessHelp.steps.requestName.heading') }}
+          </div>
+
+          <div class="font-semibold text-gray-700">
+            {{ $t('startManageBusinessHelp.steps.requestName.namedBusiness.heading') }}
+          </div>
+          <ul>
+            <li>
+              <ConnectI18nBold translation-path="startManageBusinessHelp.steps.requestName.namedBusiness.content1" />
+            </li>
+            <li>{{ $t('startManageBusinessHelp.steps.requestName.namedBusiness.content2') }}</li>
+            <li>{{ $t('startManageBusinessHelp.steps.requestName.namedBusiness.content3') }}</li>
+            <li>{{ $t('startManageBusinessHelp.steps.requestName.namedBusiness.content4') }}</li>
+            <li>
+              <ConnectI18nBold translation-path="startManageBusinessHelp.steps.requestName.namedBusiness.content5" />
+            </li>
+          </ul>
+
+          <div class="font-semibold text-gray-700">
+            {{ $t('startManageBusinessHelp.steps.requestName.numberedCompany.heading') }}
+          </div>
+          <ul>
+            <li>
+              <ConnectI18nBold translation-path="startManageBusinessHelp.steps.requestName.numberedCompany.content1" />
+            </li>
+          </ul>
+        </li>
+
+        <!-- Step 3 -->
+        <li>
+          <div class="font-semibold text-gray-900">
+            {{ $t('startManageBusinessHelp.steps.incorporateRegister.heading') }}
+          </div>
+          <ul>
+            <li>
+              <ConnectI18nBold translation-path="startManageBusinessHelp.steps.incorporateRegister.content1" />
+              <ul class="ml-4 mt-2">
+                <li>{{ $t('startManageBusinessHelp.steps.incorporateRegister.content2') }}</li>
+                <li>{{ $t('startManageBusinessHelp.steps.incorporateRegister.content3') }}</li>
+              </ul>
+            </li>
+            <li>{{ $t('startManageBusinessHelp.steps.incorporateRegister.content2') }}</li>
+            <li>{{ $t('startManageBusinessHelp.steps.incorporateRegister.content3') }}</li>
+          </ul>
+        </li>
+
+        <!-- Step 4 -->
+        <li>
+          <div class="font-semibold text-gray-900">
+            {{ $t('startManageBusinessHelp.steps.manageMaintain.heading') }}
+          </div>
+          <ul>
+            <li>{{ $t('startManageBusinessHelp.steps.manageMaintain.content1') }}</li>
+            <li>
+              <ConnectI18nBold translation-path="startManageBusinessHelp.steps.manageMaintain.content2" />
+              <ul class="ml-4 mt-2">
+                <li>{{ $t('startManageBusinessHelp.steps.manageMaintain.content3') }}</li>
+                <li>{{ $t('startManageBusinessHelp.steps.manageMaintain.content4') }}</li>
+                <li>{{ $t('startManageBusinessHelp.steps.manageMaintain.content5') }}</li>
+                <li>{{ $t('startManageBusinessHelp.steps.manageMaintain.content6') }}</li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ol>
+    </div>
     <div class="flex">
       <UButton
         :label="$t('btn.busStartHelp.hide')"

--- a/business-registry-dashboard/app/components/HelpTextSection.vue
+++ b/business-registry-dashboard/app/components/HelpTextSection.vue
@@ -17,6 +17,10 @@ const { data: helpText } = await useAsyncData('start-manage-business-help-text-'
     .where({ _locale: locale.value, _path: { $contains: 'start-manage-business-help-text' } })
     .findOne()
 })
+
+onMounted(() => {
+  console.log('helpText', helpText)
+})
 </script>
 <template>
   <UButton

--- a/business-registry-dashboard/app/locales/en-CA.ts
+++ b/business-registry-dashboard/app/locales/en-CA.ts
@@ -739,5 +739,48 @@ export default {
     error: 'Error retrieving search results, please try again later.',
     resultListLabel: 'Search Results',
     noResults: 'No results found'
+  },
+  startManageBusinessHelp: {
+    heading: 'Help with Starting and Managing a Business',
+    intro: 'Start a named or numbered business in B.C. by following these steps:',
+    steps: {
+      businessType: {
+        heading: 'Decide on a Business Type',
+        content1: 'Decide which business structure is the most appropriate for you. A few options are: a sole proprietorship, partnership, or corporation. Each structure has different legal and financial implications.',
+        content2: 'If you want to start a corporation, you also have the choice of using a named or numbered company.',
+        content3: 'Once your Name Request has been approved you must return to this screen to Incorporate or Register your business using your approved Name Request.',
+        wizardLink: 'Use the Business Structures Wizard to help you decide.'
+      },
+      requestName: {
+        heading: 'Request a Business Name or Use a Numbered Company',
+        namedBusiness: {
+          heading: 'Request a Business Name',
+          content1: 'To start a named business in B.C., change the business name of an existing company, or merge two or more companies using a new name, click the {boldStart}"Get Started with a B.C. Based Business"{boldEnd} button on this screen and follow the instructions.',
+          content2: 'Before registering or incorporating a named business, you will need to first submit a Name Request. You will be asked to create a unique name for your business and submit your name(s) for review by BC Registries staff.',
+          content3: 'Once you submit your Name Request you can return to this screen and your Name Request (NR) will automatically appear in your table.',
+          content4: 'If you do not see your Name Request in your table (e.g. if you submitted your Name Request without being logged into your BC Registries account), you can add your Name Request manually by looking up your business name or your NR number.',
+          content5: 'You can track the approval status of your Name Request from your table on this screen by clicking the {boldStart}"Open Name Request"{boldEnd} button next to your Name Request.'
+        },
+        numberedCompany: {
+          heading: 'Use a Numbered Company',
+          content1: 'To start a numbered corporation in B.C., click the {boldStart}"Get Started with a B.C. Based Business"{boldEnd} button and follow the instructions.'
+        }
+      },
+      incorporateRegister: {
+        heading: 'Incorporate or Register Your Business',
+        content1: 'For named businesses, once your Name Request has been approved and added to your table on this screen, you must select the {boldStart}"Register Now"{boldEnd} button beside the name to begin your incorporation or registration.',
+        content2: 'Follow the steps in the application and complete all of the required information including addresses, contact information, people and roles, and share structure (if applicable).',
+        content3: 'Retain a copy of all incorporation or registration documents for your business\' records.'
+      },
+      manageMaintain: {
+        heading: 'Manage and Maintain Your Business',
+        content1: 'Once your business is incorporated or registered you are required to keep information about your business up to date with the Business Registry.',
+        content2: 'From your table, click {boldStart}"Manage Business"{boldEnd} to manage and maintain your business information including:',
+        content3: 'View and change business information.',
+        content4: 'See when annual reports are due and file them each year (if applicable).',
+        content5: 'See the history of your business\' filings and download copies of all documents.',
+        content6: 'Dissolve your business.'
+      }
+    }
   }
 }

--- a/business-registry-dashboard/app/locales/fr-CA.ts
+++ b/business-registry-dashboard/app/locales/fr-CA.ts
@@ -729,5 +729,48 @@ export default {
     error: 'Erreur lors de la récupération des résultats, veuillez réessayer plus tard.',
     resultListLabel: 'Résultats de la recherche',
     noResults: 'Aucun résultat trouvé'
+  },
+  startManageBusinessHelp: {
+    heading: 'Aide pour Démarrer et Gérer une Entreprise',
+    intro: 'Démarrez une entreprise nommée ou numérotée en C.-B. en suivant ces étapes :',
+    steps: {
+      businessType: {
+        heading: "Choisir un Type d'Entreprise",
+        content1: "Décidez quelle structure d'entreprise est la plus appropriée pour vous. Quelques options sont : une entreprise individuelle, une société en nom collectif ou une société par actions. Chaque structure a des implications juridiques et financières différentes.",
+        content2: "Si vous souhaitez créer une société par actions, vous avez également le choix d'utiliser une entreprise nommée ou numérotée.",
+        content3: 'Une fois que votre demande de nom a été approuvée, vous devez revenir à cet écran pour constituer ou enregistrer votre entreprise en utilisant votre demande de nom approuvée.',
+        wizardLink: "Utilisez l'Assistant des Structures d'Entreprise pour vous aider à décider."
+      },
+      requestName: {
+        heading: "Demander un Nom d'Entreprise ou Utiliser une Entreprise Numérotée",
+        namedBusiness: {
+          heading: "Demander un Nom d'Entreprise",
+          content1: "Pour démarrer une entreprise nommée en C.-B., changer le nom d'une entreprise existante, ou fusionner deux entreprises ou plus en utilisant un nouveau nom, cliquez sur le bouton {boldStart}'Commencer avec une entreprise basée en C.-B.'{boldEnd} sur cet écran et suivez les instructions.",
+          content2: "Avant d'enregistrer ou de constituer une entreprise nommée, vous devrez d'abord soumettre une demande de nom. On vous demandera de créer un nom unique pour votre entreprise et de soumettre votre ou vos noms pour examen par le personnel des Registres BC.",
+          content3: 'Une fois que vous aurez soumis votre demande de nom, vous pourrez revenir à cet écran et votre demande de nom (NR) apparaîtra automatiquement dans votre tableau.',
+          content4: 'Si vous ne voyez pas votre demande de nom dans votre tableau (par exemple, si vous avez soumis votre demande de nom sans être connecté à votre compte des Registres BC), vous pouvez ajouter votre demande de nom manuellement en recherchant le nom de votre entreprise ou votre numéro NR.',
+          content5: "Vous pouvez suivre l'état d'approbation de votre demande de nom depuis votre tableau sur cet écran en cliquant sur le bouton {boldStart}'Ouvrir la Demande de Nom'{boldEnd} à côté de votre demande de nom."
+        },
+        numberedCompany: {
+          heading: 'Utiliser une Entreprise Numérotée',
+          content1: "Pour démarrer une société numérotée en C.-B., cliquez sur le bouton {boldStart}'Commencer avec une entreprise basée en C.-B.'{boldEnd} et suivez les instructions."
+        }
+      },
+      incorporateRegister: {
+        heading: 'Constituer ou Enregistrer Votre Entreprise',
+        content1: "Pour les entreprises nommées, une fois que votre demande de nom a été approuvée et ajoutée à votre tableau sur cet écran, vous devez sélectionner le bouton {boldStart}'Enregistrer Maintenant'{boldEnd} à côté du nom pour commencer votre constitution ou votre enregistrement.",
+        content2: 'Suivez les étapes de la demande et remplissez toutes les informations requises, y compris les adresses, les coordonnées, les personnes et les rôles, et la structure des actions (le cas échéant).',
+        content3: "Conservez une copie de tous les documents de constitution ou d'enregistrement pour les dossiers de votre entreprise."
+      },
+      manageMaintain: {
+        heading: 'Gérer et Maintenir Votre Entreprise',
+        content1: 'Une fois que votre entreprise est constituée ou enregistrée, vous êtes tenu de maintenir à jour les informations concernant votre entreprise auprès du Registre des entreprises.',
+        content2: "Depuis votre tableau, cliquez sur {boldStart}'Gérer l'Entreprise'{boldEnd} pour gérer et maintenir les informations de votre entreprise, notamment :",
+        content3: "Consulter et modifier les informations de l'entreprise.",
+        content4: 'Voir quand les rapports annuels sont dus et les déposer chaque année (le cas échéant).',
+        content5: "Consulter l'historique des dépôts de votre entreprise et télécharger des copies de tous les documents.",
+        content6: 'Dissoudre votre entreprise.'
+      }
+    }
   }
 }

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/25286

Fixed this:
![image](https://github.com/user-attachments/assets/55632759-447d-4ae2-961d-4785e7ed5e65)


## This was extremely annoying to fix. Here's why:
Previously, that help text was being rendered by a markdown (.md) file. Every time I tried a fix, it WORKS locally but when I create a temp link, it DOESN'T work. I kept going back and forth many times but to no avail. You can tell by the amount of comments deleted 😁 

So, I decided to move away altogether from using those markdown files for now. I want to get this moved forward because I need to be done with this and another ticket by tomorrow.