### PR TITLE
24660 - Display Withdrawn Status in BRD

### DIFF
--- a/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
+++ b/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
@@ -154,6 +154,9 @@ function getPrimaryActionLabel (item: Business): string {
   }
 
   if (isTemporaryBusiness(item)) {
+    if (item.draftStatus === 'WITHDRAWN') {
+      return t('labels.manageBusiness')
+    }
     return t('labels.resumeDraft')
   }
   if (isNameRequest(item)) {

--- a/business-registry-dashboard/app/enums/business-state.ts
+++ b/business-registry-dashboard/app/enums/business-state.ts
@@ -2,4 +2,5 @@ export enum BusinessState {
   ACTIVE = 'Active',
   DRAFT = 'Draft',
   HISTORICAL = 'Historical',
+  WITHDRAWN = 'Withdrawn'
 }

--- a/business-registry-dashboard/app/interfaces/affiliation.ts
+++ b/business-registry-dashboard/app/interfaces/affiliation.ts
@@ -38,6 +38,7 @@ export interface AlternateNames {
 export interface AffiliationResponse {
   identifier?: string
   draftType?: CorpTypes
+  draftStatus?: string
   legalType?: CorpTypes
   businessNumber?: string
   name?: string

--- a/business-registry-dashboard/app/interfaces/business.ts
+++ b/business-registry-dashboard/app/interfaces/business.ts
@@ -28,6 +28,7 @@ export interface Business {
     contacts?: Contact[]
     corpType: CorpType
     corpSubType?: CorpType
+    draftStatus?: string
     folioNumber?: string
     lastModified?: string
     modified?: string

--- a/business-registry-dashboard/app/utils/affiliations.ts
+++ b/business-registry-dashboard/app/utils/affiliations.ts
@@ -98,6 +98,9 @@ export const affiliationType = (business: Business): string => {
 /** Returns the status of the affiliation. */ // TODO: add i18n for these states
 export const affiliationStatus = (business: Business): string => {
   if (isTemporaryBusiness(business)) {
+    if (business.draftStatus === 'WITHDRAWN') {
+      return BusinessState.WITHDRAWN
+    }
     return BusinessState.DRAFT
   }
   if (isNameRequest(business)) {

--- a/business-registry-dashboard/app/utils/business.ts
+++ b/business-registry-dashboard/app/utils/business.ts
@@ -55,7 +55,8 @@ export function buildBusinessObject (resp: AffiliationResponse): Business {
     ...(resp.nrNumber && { nrNumber: resp.nrNumber }),
     ...(resp.adminFreeze !== undefined ? { adminFreeze: resp.adminFreeze } : { adminFreeze: false }),
     ...(resp.goodStanding !== undefined ? { goodStanding: resp.goodStanding } : { goodStanding: true }),
-    ...(resp.state && { status: resp.state })
+    ...(resp.state && { status: resp.state }),
+    ...(resp.draftStatus && { draftStatus: resp.draftStatus })
   }
 }
 

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
Issue #: /https://github.com/bcgov/entity/issues/24660

- Add the status of Withdrawn in BRD
- Add withdrawn status filter to the BRD
- with action to remove it from BRD Remove from table option is available when user selects the drop down
- Primary action is to "Manage Business"
- When user selects "Manage Business" display entity dashboard
