### PR TITLE
fixed: incorp now link to show dialog error if NR not processed yet

### DIFF
--- a/business-registry-dashboard/app/pages/incorporateNow.vue
+++ b/business-registry-dashboard/app/pages/incorporateNow.vue
@@ -81,7 +81,7 @@ onMounted(async () => {
     // Check basic eligibility conditions
     const isEligibleRequest = business.nameRequest.requestActionCd === NrRequestActionCodes.NEW_BUSINESS &&
       ELIGIBLE_CORP_TYPES.includes(business.nameRequest.legalType) &&
-      nameRequest.expirationDate
+      !!nameRequest.expirationDate
 
     if (!isEligibleRequest) {
       throw new Error('Invalid name request')

--- a/business-registry-dashboard/app/pages/incorporateNow.vue
+++ b/business-registry-dashboard/app/pages/incorporateNow.vue
@@ -80,7 +80,8 @@ onMounted(async () => {
 
     // Check basic eligibility conditions
     const isEligibleRequest = business.nameRequest.requestActionCd === NrRequestActionCodes.NEW_BUSINESS &&
-      ELIGIBLE_CORP_TYPES.includes(business.nameRequest.legalType)
+      ELIGIBLE_CORP_TYPES.includes(business.nameRequest.legalType) &&
+      nameRequest.expirationDate
 
     if (!isEligibleRequest) {
       throw new Error('Invalid name request')

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/25427

Before I approved my NR:
![before approval nr](https://github.com/user-attachments/assets/11e6f0d1-6a4f-4a77-a229-5575999c744c)

If you take a look at the console, the expiration date is null. As long as that expiration date is null, the NR isn't fully ready to be consumed yet. So, we'll show that nice error dialog.