### PR TITLE
22683 remove delete continuation functionality

### DIFF
--- a/business-registry-dashboard/app/components/Modal/RemoveBusiness/Generic.vue
+++ b/business-registry-dashboard/app/components/Modal/RemoveBusiness/Generic.vue
@@ -9,6 +9,13 @@ defineEmits<{
   confirm: [void]
   close: [void]
 }>()
+function selectDescription (removeBusinessPayload: RemoveBusinessPayload) {
+  // Different discriptions for Continuation In's if they have a name request
+  if (removeBusinessPayload.business.corpType.code === CorpTypes.CONTINUATION_IN && removeBusinessPayload.business.nameRequest) {
+    return `modal.removeBusiness.generic.${removeBusinessPayload.business.corpType.code}.descriptionNamed`
+  }
+  return `modal.removeBusiness.generic.${removeBusinessPayload.business.corpType.code}.description`
+}
 </script>
 <template>
   <div class="flex flex-col items-center gap-4 text-center">
@@ -16,7 +23,7 @@ defineEmits<{
     <h2 class="text-xl font-semibold">
       {{ $t(`modal.removeBusiness.generic.${removeBusinessPayload.business.corpType.code}.title`) }}
     </h2>
-    <p>{{ $t(`modal.removeBusiness.generic.${removeBusinessPayload.business.corpType.code}.description`) }}</p>
+    <p>{{ $t(selectDescription(removeBusinessPayload)) }}</p>
     <div class="mt-2 flex flex-wrap items-center justify-center gap-4">
       <UButton
         :block="isSmallScreen"

--- a/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
+++ b/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
@@ -386,7 +386,6 @@ const showAffiliationInvitationCancelRequestButton = (item: Business): boolean =
 
 const moreActionsDropdownOptions = computed<DropdownItem[][]>(() => {
   const options = []
-  console.log(props)
   if (showAffiliationInvitationNewRequestButton(props.item)) {
     options.push({
       label: t('labels.newRequest'),
@@ -436,13 +435,6 @@ const moreActionsDropdownOptions = computed<DropdownItem[][]>(() => {
   return [options]
 })
 
-function canBusinessBeDeleted (item: Business) {
-  if (item.corpType.code === CorpTypes.CONTINUATION_IN && item?.draftStatus !== EntityStates.DRAFT) {
-    return false
-  } else {
-    return true
-  }
-}
 </script>
 <template>
   <div

--- a/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
+++ b/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
@@ -386,6 +386,7 @@ const showAffiliationInvitationCancelRequestButton = (item: Business): boolean =
 
 const moreActionsDropdownOptions = computed<DropdownItem[][]>(() => {
   const options = []
+  console.log(props)
   if (showAffiliationInvitationNewRequestButton(props.item)) {
     options.push({
       label: t('labels.newRequest'),
@@ -432,9 +433,16 @@ const moreActionsDropdownOptions = computed<DropdownItem[][]>(() => {
       icon: 'i-mdi-checkbox-multiple-blank-outline'
     })
   }
-
   return [options]
 })
+
+function canBusinessBeDeleted (item: Business) {
+  if (item.corpType.code === CorpTypes.CONTINUATION_IN && item?.draftStatus !== EntityStates.DRAFT) {
+    return false
+  } else {
+    return true
+  }
+}
 </script>
 <template>
   <div

--- a/business-registry-dashboard/app/composables/useBrdModals.ts
+++ b/business-registry-dashboard/app/composables/useBrdModals.ts
@@ -65,15 +65,10 @@ export const useBrdModals = () => {
 
   function openBusinessRemovalConfirmation (removeBusinessPayload: RemoveBusinessPayload) {
     const type = removeBusinessPayload.business.corpType.code
-    if ([CorpTypes.NAME_REQUEST,
-      CorpTypes.INCORPORATION_APPLICATION,
-      CorpTypes.AMALGAMATION_APPLICATION,
-      CorpTypes.REGISTRATION,
-      CorpTypes.PARTNERSHIP,
-      CorpTypes.SOLE_PROP].includes(type)) {
-      modal.open(ModalRemoveBusiness, { removeBusinessPayload, type: 'generic' })
-    } else {
+    if (type === CorpTypes.COOP) {
       modal.open(ModalRemoveBusiness, { removeBusinessPayload, type: 'passcode' })
+    } else {
+      modal.open(ModalRemoveBusiness, { removeBusinessPayload, type: 'generic' })
     }
   }
 

--- a/business-registry-dashboard/app/locales/en-CA.ts
+++ b/business-registry-dashboard/app/locales/en-CA.ts
@@ -556,7 +556,7 @@ export default {
         },
         CTMP: {
           title: 'Delete Continuation Application',
-          description: 'This action will permanently delete your Continuation Application',
+          description: 'This action will permanently delete your Continuation Application.',
           descriptionNamed: 'This action will permanently delete your Continuation Application. However, you will be able to use your Name Request to start a new Continuation Application.',
           primaryBtnLabel: 'Delete Application',
           secondaryBtnLabel: 'Cancel'

--- a/business-registry-dashboard/app/locales/en-CA.ts
+++ b/business-registry-dashboard/app/locales/en-CA.ts
@@ -554,6 +554,37 @@ export default {
           primaryBtnLabel: 'Remove Registration',
           secondaryBtnLabel: 'Keep Registration'
         },
+        CTMP: {
+          title: 'Delete Continuation Application',
+          description: 'This action will permanently delete your Continuation Application',
+          descriptionNamed: 'This action will permanently delete your Continuation Application. However, you will be able to use your Name Request to start a new Continuation Application.',
+          primaryBtnLabel: 'Delete Application',
+          secondaryBtnLabel: 'Cancel'
+        },
+        C: {
+          title: 'Remove from Table',
+          description: 'This business will be removed from your Business Registry list and will no longer be linked to this account. You can add the business back to your account later on.',
+          primaryBtnLabel: 'Remove Business',
+          secondaryBtnLabel: 'Cancel'
+        },
+        CBEN: {
+          title: 'Remove from Table',
+          description: 'This business will be removed from your Business Registry list and will no longer be linked to this account. You can add the business back to your account later on.',
+          primaryBtnLabel: 'Remove Business',
+          secondaryBtnLabel: 'Cancel'
+        },
+        CCC: {
+          title: 'Remove from Table',
+          description: 'This business will be removed from your Business Registry list and will no longer be linked to this account. You can add the business back to your account later on.',
+          primaryBtnLabel: 'Remove Business',
+          secondaryBtnLabel: 'Cancel'
+        },
+        CUL: {
+          title: 'Remove from Table',
+          description: 'This business will be removed from your Business Registry list and will no longer be linked to this account. You can add the business back to your account later on.',
+          primaryBtnLabel: 'Remove Business',
+          secondaryBtnLabel: 'Cancel'
+        },
         SP: {
           title: 'Remove Registration?',
           description: 'Removing this registration will remove the associated business from your Business Registry list. To add the business back to the My Business Registry list later, you will need the business registration number and the name of the proprietor exactly as it appears on the registration application.',

--- a/business-registry-dashboard/app/locales/fr-CA.ts
+++ b/business-registry-dashboard/app/locales/fr-CA.ts
@@ -544,6 +544,37 @@ export default {
           primaryBtnLabel: "Supprimer L'Enregistrement",
           secondaryBtnLabel: "Conserver L'Enregistrement"
         },
+        CTMP: {
+          title: 'Supprimer la Demande de Continuation',
+          description: 'Cette action supprimera définitivement votre Demande de Continuation.',
+          descriptionNamed: 'Cette action supprimera définitivement votre Demande de Continuation. Cependant, vous pourrez utiliser votre Demande de Nom pour démarrer une nouvelle Demande de Continuation.',
+          primaryBtnLabel: "Supprimer l'application",
+          secondaryBtnLabel: 'Annuler'
+        },
+        C: {
+          title: 'Supprimer du Tableau',
+          description: "Cette entreprise sera supprimée de votre liste du registre des entreprises et ne sera plus liée à ce compte. Vous pourrez rajouter l'entreprise à votre compte ultérieurement.",
+          primaryBtnLabel: "Supprimer l'entreprise",
+          secondaryBtnLabel: 'Annuler'
+        },
+        CBEN: {
+          title: 'Supprimer du Tableau',
+          description: "Cette entreprise sera supprimée de votre liste du registre des entreprises et ne sera plus liée à ce compte. Vous pourrez rajouter l'entreprise à votre compte ultérieurement.",
+          primaryBtnLabel: "Supprimer l'entreprise",
+          secondaryBtnLabel: 'Annuler'
+        },
+        CCC: {
+          title: 'Supprimer du Tableau',
+          description: "Cette entreprise sera supprimée de votre liste du registre des entreprises et ne sera plus liée à ce compte. Vous pourrez rajouter l'entreprise à votre compte ultérieurement.",
+          primaryBtnLabel: "Supprimer l'entreprise",
+          secondaryBtnLabel: 'Annuler'
+        },
+        CUL: {
+          title: 'Supprimer du Tableau',
+          description: "Cette entreprise sera supprimée de votre liste du registre des entreprises et ne sera plus liée à ce compte. Vous pourrez rajouter l'entreprise à votre compte ultérieurement.",
+          primaryBtnLabel: "Supprimer l'entreprise",
+          secondaryBtnLabel: 'Annuler'
+        },
         SP: {
           title: "Supprimer L'Enregistrement?",
           description: "La suppression de cet enregistrement le retirera de votre liste de registre des entreprises. Pour réintégrer l'entreprise à la liste de registre des entreprises plus tard, vous aurez besoin du numéro d'enregistrement de l'entreprise et du nom du propriétaire exactement comme il apparaît sur la demande d'enregistrement.",

--- a/business-registry-dashboard/app/stores/affiliations.ts
+++ b/business-registry-dashboard/app/stores/affiliations.ts
@@ -75,7 +75,10 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
   /* Check if Business can be deleted safely (i.e. does not have a review record) */
   function canBusinessBeDeleted (payload: RemoveBusinessPayload) {
     // For now only including Continuation Ins where only draft records can be deleted
-    if (payload.business.corpType.code === CorpTypes.CONTINUATION_IN && payload.business?.draftStatus !== EntityStates.DRAFT) {
+    if (payload.business.corpType.code === CorpTypes.CONTINUATION_IN &&
+      payload.business?.draftStatus &&
+      payload.business.draftStatus !== EntityStates.DRAFT
+    ) {
       return false
     } else {
       return true

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/business-registry-dashboard/tests/unit/composables/useBrdModals.test.ts
+++ b/business-registry-dashboard/tests/unit/composables/useBrdModals.test.ts
@@ -162,7 +162,10 @@ describe('useBrdModals', () => {
         CorpTypes.AMALGAMATION_APPLICATION,
         CorpTypes.REGISTRATION,
         CorpTypes.PARTNERSHIP,
-        CorpTypes.SOLE_PROP].forEach((item) => {
+        CorpTypes.SOLE_PROP,
+        CorpTypes.CONTINUE_IN,
+        'future types' // Future types will automatically get generic module rather than passcode
+      ].forEach((item) => {
         const payload = {
           business: { corpType: { code: item } }
         }
@@ -193,10 +196,10 @@ describe('useBrdModals', () => {
         vi.restoreAllMocks()
       })
     })
-
+    // Only COOPs should have the passcode model
     it('should open ModalRemoveBusiness for passcode type', () => {
       const payload = {
-        business: { corpType: { code: 'some other code' } }
+        business: { corpType: { code: CorpTypes.COOP } }
       }
 
       // @ts-expect-error - payload arg doesnt match function param
@@ -213,7 +216,7 @@ describe('useBrdModals', () => {
           removeBusinessPayload: {
             business: {
               corpType: {
-                code: 'some other code'
+                code: 'CP'
               }
             }
           },

--- a/business-registry-dashboard/tests/unit/composables/useBrdModals.test.ts
+++ b/business-registry-dashboard/tests/unit/composables/useBrdModals.test.ts
@@ -155,7 +155,16 @@ describe('useBrdModals', () => {
     })
   })
 
+  /* There are two types of modals available, generic and passcode.
+     The passcode type model is only used for COOPs.
+  */
   describe('openBusinessRemovalConfirmation', () => {
+  /* Testing that the generic Modal is used.
+
+    This should show for anything that is included in the CorpTypes enum
+    - i.e bootstrap filings, societies and business types (other than COOPS).
+    Because it is the current default, it will show as long as it receives a string.
+  */
     it('should open ModalRemoveBusiness for generic type', () => {
       [CorpTypes.NAME_REQUEST,
         CorpTypes.INCORPORATION_APPLICATION,
@@ -196,7 +205,9 @@ describe('useBrdModals', () => {
         vi.restoreAllMocks()
       })
     })
-    // Only COOPs should have the passcode model
+
+    /* Testing that the passcode Modal is used.
+      This should show for COOPS only. */
     it('should open ModalRemoveBusiness for passcode type', () => {
       const payload = {
         business: { corpType: { code: CorpTypes.COOP } }


### PR DESCRIPTION
Issue #: https://github.com/bcgov/entity/issues/22683

Description of changes:


- Updated logic so that Continue In's would be successfully deleted or removed (have affiliations removed). 
- Added in wording in accordance with the Figma design here: https://www.figma.com/design/rNe2jn8wyFykKRzwiBo6ar/Continuation-In-V6?node-id=2188-39977&p=f&t=e3LnVAu9pjqKCmAb-0
- Refactored some related code

Also addresses following tickets:
Issue #: https://github.com/bcgov/entity/issues/24079
Issue #: https://github.com/bcgov/entity/issues/24986

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).