### PR TITLE
fix: fixed inconsistency in how to display zombie corps

### DIFF
--- a/business-registry-dashboard/app/utils/affiliations.ts
+++ b/business-registry-dashboard/app/utils/affiliations.ts
@@ -295,9 +295,6 @@ export const isNumberedIncorporationApplication = (item: Business): boolean => {
 
 // /** Returns the identifier of the affiliation. */
 export const number = (business: Business): string => {
-  if (isNumberedIncorporationApplication(business)) {
-    return AffidavitNumberStatus.PENDING
-  }
   if (isTemporaryBusiness(business) || isNameRequest(business)) {
     return business.nameRequest?.nrNumber || business.nrNumber || ''
   }

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/business-registry-dashboard/tests/unit/utils/affiliations.test.ts
+++ b/business-registry-dashboard/tests/unit/utils/affiliations.test.ts
@@ -388,14 +388,14 @@ describe('affiliations utils', () => {
   })
 
   describe('number', () => {
-    it('should return "Pending" for a numbered incorporation application', () => {
+    it('should return empty string for a numbered incorporation application', () => {
       const business: Business = {
         businessIdentifier: 'BC1234567',
         corpType: { code: CorpTypes.INCORPORATION_APPLICATION },
         corpSubType: { code: CorpTypes.BC_COMPANY }
       }
 
-      expect(number(business)).toBe(AffidavitNumberStatus.PENDING)
+      expect(number(business)).toBe('')
     })
 
     it('should return nrNumber if the business is a temporary business', () => {


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/26375

 Inconsistency in how Zombie corps are displayed in BRD. Now empty string for all to stay consistent (as was decided). 