### PR TITLE
26365 fixed removing withdrawn filings error

### DIFF
--- a/business-registry-dashboard/app/stores/affiliations.ts
+++ b/business-registry-dashboard/app/stores/affiliations.ts
@@ -497,6 +497,7 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
     createAffiliation,
     handleManageBusinessOrNameRequest,
     removeBusiness,
+    canBusinessBeDeleted,
     removeAffiliation,
     getFilings,
     deleteBusinessFiling,

--- a/business-registry-dashboard/app/stores/affiliations.ts
+++ b/business-registry-dashboard/app/stores/affiliations.ts
@@ -46,7 +46,6 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
   async function removeBusiness (payload: RemoveBusinessPayload) {
     const orgId = (route.params.orgId && isStaffOrSbcStaff.value) ? route.params.orgId : payload.orgIdentifier
     // If the business is a new IA, amalgamation, or registration then remove the business filing from legal-db
-    // TODO: Add continuation in to the list of filings to remove (for MVP)
     if ([
       CorpTypes.INCORPORATION_APPLICATION,
       CorpTypes.AMALGAMATION_APPLICATION,
@@ -72,17 +71,20 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
     }
   }
 
-  /* Check if Business can be deleted safely (i.e. does not have a review record) */
+  /* Check if Business can be deleted safely. */
   function canBusinessBeDeleted (payload: RemoveBusinessPayload) {
-    // For now only including Continuation Ins where only draft records can be deleted
-    if (payload.business.corpType.code === CorpTypes.CONTINUATION_IN &&
-      payload.business?.draftStatus &&
-      payload.business.draftStatus !== EntityStates.DRAFT
-    ) {
-      return false
-    } else {
+    const { draftStatus, corpType } = payload.business
+
+    // Allow deletion if there's no draft status
+    if (!draftStatus) {
       return true
     }
+
+    // Don't allow deletion if:
+    // 1. It's withdrawn, or
+    // 2. It's a continuation in with non-draft status since only draft records can be deleted
+    return draftStatus !== EntityStates.WITHDRAWN &&
+           !(corpType.code === CorpTypes.CONTINUATION_IN && draftStatus !== EntityStates.DRAFT)
   }
 
   function removeInvite (inviteId: number) {

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/business-registry-dashboard/tests/unit/stores/affiliations.test.ts
+++ b/business-registry-dashboard/tests/unit/stores/affiliations.test.ts
@@ -3,6 +3,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 import { mockAffiliationResponse } from '~~/tests/mocks/mockedData'
+import { EntityStates } from '@bcrs-shared-components/enums'
 
 let mockAuthenticated = true
 const mockAuthApi = vi.fn()
@@ -925,6 +926,98 @@ describe('useAffiliationsStore', () => {
         })
       )
       expect(mockLegalApi).not.toHaveBeenCalled() // should not call deleteBusinessFiling
+    })
+  })
+
+  describe('canBusinessBeDeleted', () => {
+    let affStore: any
+
+    beforeEach(() => {
+      affStore = useAffiliationsStore()
+    })
+
+    it('should return true when draftStatus is undefined', () => {
+      const payload = {
+        business: {
+          corpType: { code: 'ANY_TYPE' },
+          draftStatus: undefined,
+          businessIdentifier: 'BC1234567'
+        },
+        orgIdentifier: 123
+      }
+
+      const result = affStore.canBusinessBeDeleted(payload)
+      expect(result).toBe(true)
+    })
+
+    it('should return true when draftStatus is null', () => {
+      const payload = {
+        business: {
+          corpType: { code: 'ANY_TYPE' },
+          draftStatus: null,
+          businessIdentifier: 'BC1234567'
+        },
+        orgIdentifier: 123
+      }
+
+      const result = affStore.canBusinessBeDeleted(payload)
+      expect(result).toBe(true)
+    })
+
+    it('should return false when draftStatus is WITHDRAWN', () => {
+      const payload = {
+        business: {
+          corpType: { code: 'ANY_TYPE' },
+          draftStatus: EntityStates.WITHDRAWN,
+          businessIdentifier: 'BC1234567'
+        },
+        orgIdentifier: 123
+      }
+
+      const result = affStore.canBusinessBeDeleted(payload)
+      expect(result).toBe(false)
+    })
+
+    it('should return false when corpType is CONTINUATION_IN and draftStatus is not DRAFT', () => {
+      const payload = {
+        business: {
+          corpType: { code: CorpTypes.CONTINUATION_IN },
+          draftStatus:  EntityStates.ACTIVE, // Any status other than DRAFT
+          businessIdentifier: 'BC1234567'
+        },
+        orgIdentifier: 123
+      }
+
+      const result = affStore.canBusinessBeDeleted(payload)
+      expect(result).toBe(false)
+    })
+
+    it('should return true when corpType is CONTINUATION_IN and draftStatus is DRAFT', () => {
+      const payload = {
+        business: {
+          corpType: { code: CorpTypes.CONTINUATION_IN },
+          draftStatus: EntityStates.DRAFT,
+          businessIdentifier: 'BC1234567'
+        },
+        orgIdentifier: 123
+      }
+
+      const result = affStore.canBusinessBeDeleted(payload)
+      expect(result).toBe(true)
+    })
+
+    it('should return true for other draftStatus values that are not WITHDRAWN', () => {
+      const payload = {
+        business: {
+          corpType: { code: 'ANY_TYPE' },
+          draftStatus: EntityStates.DRAFT,
+          businessIdentifier: 'BC1234567'
+        },
+        orgIdentifier: 123
+      }
+
+      const result = affStore.canBusinessBeDeleted(payload)
+      expect(result).toBe(true)
     })
   })
 

--- a/business-registry-dashboard/tests/unit/stores/affiliations.test.ts
+++ b/business-registry-dashboard/tests/unit/stores/affiliations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
-import { mockAffiliationResponse } from '~~/tests/mocks/mockedData'
 import { EntityStates } from '@bcrs-shared-components/enums'
+import { mockAffiliationResponse } from '~~/tests/mocks/mockedData'
 
 let mockAuthenticated = true
 const mockAuthApi = vi.fn()
@@ -982,7 +982,7 @@ describe('useAffiliationsStore', () => {
       const payload = {
         business: {
           corpType: { code: CorpTypes.CONTINUATION_IN },
-          draftStatus:  EntityStates.ACTIVE, // Any status other than DRAFT
+          draftStatus: EntityStates.ACTIVE, // Any status other than DRAFT
           businessIdentifier: 'BC1234567'
         },
         orgIdentifier: 123


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/26365

Fixed the error when trying to remove withdrawn filings.

I wasted a ton of time thinking it was a LEAR issue. I went to legal api and tried fixing the DELETE endpoint to support withdrawn filings. I realized that would delete the withdrawn filing entirely from the DB (we need to keep some record of those withdrawn filings) though so I shifted back here. We just need to delete it using that remove affiliation function where it makes that Auth API call. 