### PR TITLE
26471 added App-Name to reg-search

### DIFF
--- a/business-registry-dashboard/app/utils/reg-search.ts
+++ b/business-registry-dashboard/app/utils/reg-search.ts
@@ -14,7 +14,8 @@ export async function regSearch (queryStr: string): Promise<RegSearchResult[]> {
     headers: {
       Authorization: `Bearer ${token}`,
       'x-apikey': config.registriesSearchApiKey as string,
-      'Account-Id': accountStore.currentAccount.id
+      'Account-Id': accountStore.currentAccount.id,
+      'App-Name': useRuntimeConfig().public.appName
     }
   })
 

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue #:* bcgov/entity#26471

_SB says: well, I was told that updating the Reg Search API was low priority, but then Kial and Doug fixed the API gateway config (in all environments) yesterday. So here we are, adding the App Name header back in for these API calls._

*Description of changes:*
- app version = 1.0.29
- added App-Name to reg search calls

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).