### PR TITLE
feat: implemented error dialog for name request actions

### DIFF
--- a/business-registry-dashboard/app/components/BCReg/ContactInfo.vue
+++ b/business-registry-dashboard/app/components/BCReg/ContactInfo.vue
@@ -5,14 +5,17 @@
     </p>
     <ul>
       <li class="text-bcGovColor-midGray">
+        <UIcon name="i-mdi-phone" class="mr-1 size-[14px] text-bcGovColor-nonClickable" />
         {{ $t('contactInfo.bcRegGeneral.tollFree.title') }}
         <a class="text-blue-500 underline" :href="`tel:${$t('contactInfo.bcRegGeneral.tollFree.value')}`">{{ $t('contactInfo.bcRegGeneral.tollFree.value') }}</a>
       </li>
       <li class="text-bcGovColor-midGray">
+        <UIcon name="i-mdi-phone" class="mr-1 size-[14px] text-bcGovColor-nonClickable" />
         {{ $t('contactInfo.bcRegGeneral.victoriaOffice.title') }}
         <a class="text-blue-500 underline" :href="`tel:${$t('contactInfo.bcRegGeneral.victoriaOffice.value')}`">{{ $t('contactInfo.bcRegGeneral.victoriaOffice.value') }}</a>
       </li>
       <li class="text-bcGovColor-midGray">
+        <UIcon name="i-mdi-email" class="mr-1 size-[14px] text-bcGovColor-nonClickable" />
         {{ $t('contactInfo.bcRegGeneral.email.title') }}
         <a class="text-blue-500 underline" href="mailto:BCRegistries@gov.bc.ca?subject=BC Registries and Online Services - Support Request">BCRegistries@gov.bc.ca</a>
       </li>

--- a/business-registry-dashboard/app/components/Modal/Base.vue
+++ b/business-registry-dashboard/app/components/Modal/Base.vue
@@ -65,7 +65,7 @@ onMounted(async () => {
         <p v-if="content" class="text-bcGovColor-midGray">
           {{ content }}
         </p>
-        <div v-if="error" class="flex flex-col items-center gap-4 text-center">
+        <div v-if="error" class="-mb-4 flex flex-col items-center gap-4">
           <UIcon name="i-mdi-alert-circle-outline" class="-mt-10 size-8 text-red-500" />
           <h2 class="text-xl font-semibold">
             {{ error.title }}
@@ -73,9 +73,6 @@ onMounted(async () => {
           <p>{{ error.description }}</p>
           <p v-if="error.description2">
             {{ error.description2 }}
-          </p>
-          <p v-if="error.showContactInfo" class="self-start">
-            Please contact us if you require assistance.
           </p>
           <BCRegContactInfo v-if="error.showContactInfo" class="self-start text-left" />
         </div>
@@ -90,6 +87,7 @@ onMounted(async () => {
               :label="action.label"
               :variant="action.variant || 'solid'"
               :color="action.color || 'primary'"
+              class="px-7 py-3"
               @click="action.handler"
             />
           </div>

--- a/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
+++ b/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
@@ -71,7 +71,6 @@ async function createBusinessRecord (business: Business): Promise<string> {
 
   if (payload) {
     try {
-      throw new Error('Test error')
       filingResponse = await createNamedBusiness(payload) as BusinessResponse
       if (filingResponse?.errorMsg) {
         // Handle explicit error message from API response and prevent navigation

--- a/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
+++ b/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
@@ -31,6 +31,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'unknown-error': [void]
+  'name-request-action-error': [void]
   'remove-business': [{ orgIdentifier: string, business: Business }]
   'business-unavailable-error': [action: string]
   'resend-affiliation-invitation': [item: Business]
@@ -69,14 +70,23 @@ async function createBusinessRecord (business: Business): Promise<string> {
   }
 
   if (payload) {
-    filingResponse = await createNamedBusiness(payload) as BusinessResponse
+    try {
+      throw new Error('Test error')
+      filingResponse = await createNamedBusiness(payload) as BusinessResponse
+      if (filingResponse?.errorMsg) {
+        // Handle explicit error message from API response and prevent navigation
+        emit('name-request-action-error')
+        return ''
+      }
+      return filingResponse?.filing?.business?.identifier || ''
+    } catch (error) {
+      // Log the error for debugging and emit event to show appropriate error dialog to user
+      logFetchError(error, 'Failed to create business record')
+      emit('name-request-action-error')
+      return ''
+    }
   }
-
-  if (filingResponse?.errorMsg) {
-    emit('unknown-error')
-    return ''
-  }
-  return filingResponse?.filing?.business?.identifier || ''
+  return ''
 }
 
 const showAffiliationInvitationNewRequestButton = (item: Business): boolean => {

--- a/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
+++ b/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
@@ -74,7 +74,7 @@ async function createBusinessRecord (business: Business): Promise<string> {
       filingResponse = await createNamedBusiness(payload) as BusinessResponse
       if (filingResponse?.errorMsg) {
         // Handle explicit error message from API response and prevent navigation
-        emit('name-request-action-error')
+        emit('unknown-error')
         return ''
       }
       return filingResponse?.filing?.business?.identifier || ''

--- a/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
+++ b/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
@@ -408,6 +408,7 @@ const mapDetailsWithEffectiveDate = (details: any[], row: any) => {
           :index="index"
           :affiliations="affStore.affiliations.results"
           @unknown-error="brdModal.openBusinessAddError()"
+          @name-request-action-error="brdModal.nameRequestActionError()"
           @business-unavailable-error="brdModal.openBusinessUnavailableError"
           @remove-business="brdModal.openBusinessRemovalConfirmation"
           @resend-affiliation-invitation="affStore.resendAffiliationInvitation(row)"

--- a/business-registry-dashboard/app/composables/useAffiliationNavigation.ts
+++ b/business-registry-dashboard/app/composables/useAffiliationNavigation.ts
@@ -61,7 +61,9 @@ export function useAffiliationNavigation () {
   async function goToRegister (item: Business, cb: (item: Business) => Promise<string>) {
     if (isModernizedEntity(item)) {
       const businessIdentifier = await cb(item)
-      goToDashboard(businessIdentifier)
+      if (businessIdentifier) {
+        goToDashboard(businessIdentifier)
+      }
     } else if (isSocieties(item)) {
       goToSocieties()
     } else if (isOtherEntities(item)) {
@@ -74,7 +76,9 @@ export function useAffiliationNavigation () {
   async function goToAmalgamate (item: Business, cb: (item: Business) => Promise<string>) {
     if (isSupportedAmalgamationEntities(item)) {
       const businessIdentifier = await cb(item)
-      goToDashboard(businessIdentifier)
+      if (businessIdentifier) {
+        goToDashboard(businessIdentifier)
+      }
     } else {
       goToCorpOnline()
     }
@@ -83,7 +87,9 @@ export function useAffiliationNavigation () {
   async function goToContinuationIn (item: Business, cb: (item: Business) => Promise<string>) {
     if (isSupportedContinuationInEntities(item)) {
       const businessIdentifier = await cb(item)
-      goToDashboard(businessIdentifier)
+      if (businessIdentifier) {
+        goToDashboard(businessIdentifier)
+      }
     } else {
       goToCorpOnline()
     }

--- a/business-registry-dashboard/app/composables/useBrdModals.ts
+++ b/business-registry-dashboard/app/composables/useBrdModals.ts
@@ -35,9 +35,13 @@ export const useBrdModals = () => {
     modal.open(ModalBase, {
       error: {
         title: t('error.nameRequestAction.title'),
-        description: t('error.nameRequestAction.description')
+        description: t('error.nameRequestAction.description'),
+        showContactInfo: true
       },
-      actions: [{ label: t('btn.close'), handler: () => close() }]
+      actions: [
+        { label: t('btn.goBack'), variant: 'outline', handler: () => close() },
+        { label: t('btn.refreshPage'), handler: () => window.location.reload() }
+      ]
     })
   }
 

--- a/business-registry-dashboard/app/composables/useBrdModals.ts
+++ b/business-registry-dashboard/app/composables/useBrdModals.ts
@@ -31,6 +31,16 @@ export const useBrdModals = () => {
     })
   }
 
+  function nameRequestActionError () {
+    modal.open(ModalBase, {
+      error: {
+        title: t('error.nameRequestAction.title'),
+        description: t('error.nameRequestAction.description')
+      },
+      actions: [{ label: t('btn.close'), handler: () => close() }]
+    })
+  }
+
   function openMagicLinkModal (title: string, description: string, description2?: string) {
     modal.open(ModalBase, {
       error: {
@@ -98,6 +108,7 @@ export const useBrdModals = () => {
     openManageNameRequest,
     openManageNRError,
     openBusinessAddError,
+    nameRequestActionError,
     openBusinessUnavailableError,
     openInvalidFilingApplication,
     openBusinessRemovalConfirmation,

--- a/business-registry-dashboard/app/locales/en-CA.ts
+++ b/business-registry-dashboard/app/locales/en-CA.ts
@@ -167,6 +167,10 @@ export default {
       title: 'Error Adding Existing Business',
       description: 'An error occurred adding your business. Please try again.'
     },
+    nameRequestAction: {
+      title: 'Error Processing Name Request Action',
+      description: 'An error occurred processing the name request action. Please try again.'
+    },
     businessUnavailable: {
       changeName: {
         title: 'Business Unavailable',

--- a/business-registry-dashboard/app/locales/en-CA.ts
+++ b/business-registry-dashboard/app/locales/en-CA.ts
@@ -119,11 +119,12 @@ export default {
     tryAgain: 'Try Again',
     cancel: 'Cancel',
     ok: 'OK',
+    refreshPage: 'Refresh Page',
     refreshTable: 'Refresh Table'
   },
   contactInfo: {
     bcRegGeneral: {
-      title: 'If this problem continues, please contact us at:',
+      title: 'If this problem continues, please contact us for help.',
       tollFree: {
         title: 'Toll Free:',
         value: '1-877-370-1033'
@@ -168,8 +169,8 @@ export default {
       description: 'An error occurred adding your business. Please try again.'
     },
     nameRequestAction: {
-      title: 'Error Processing Name Request Action',
-      description: 'An error occurred processing the name request action. Please try again.'
+      title: 'Name Request Error',
+      description: 'We cannot display this information right now. Please try refreshing the page.'
     },
     businessUnavailable: {
       changeName: {

--- a/business-registry-dashboard/app/locales/fr-CA.ts
+++ b/business-registry-dashboard/app/locales/fr-CA.ts
@@ -119,11 +119,12 @@ export default {
     tryAgain: 'Essayer à nouveau',
     cancel: 'Annuler',
     ok: "D'accord",
+    refreshPage: 'Rafraîchir la page',
     refreshTable: 'Rafraîchir le tableau'
   },
   contactInfo: {
     bcRegGeneral: {
-      title: 'Si ce problème persiste, veuillez nous contacter à:',
+      title: 'Si ce problème persiste, veuillez nous contacter pour obtenir de l\'aide.',
       tollFree: {
         title: 'Sans Frais:',
         value: '1-877-370-1033'
@@ -168,8 +169,8 @@ export default {
       description: "Une erreur s'est produite lors de l'ajout de votre entreprise. Veuillez réessayer."
     },
     nameRequestAction: {
-      title: "Erreur lors du Traitement de l'Action de Demande de Nom",
-      description: "Une erreur s'est produite lors du traitement de l'action de demande de nom. Veuillez réessayer."
+      title: 'Erreur de Demande de Nom',
+      description: 'Nous ne pouvons pas afficher ces informations pour le moment. Veuillez réessayer plus tard.'
     },
     invalidFilingApplication: {
       title: '{type} Invalide',

--- a/business-registry-dashboard/app/locales/fr-CA.ts
+++ b/business-registry-dashboard/app/locales/fr-CA.ts
@@ -167,6 +167,10 @@ export default {
       title: "Error lors de l'ajout de l'Entreprise Existante",
       description: "Une erreur s'est produite lors de l'ajout de votre entreprise. Veuillez réessayer."
     },
+    nameRequestAction: {
+      title: "Erreur lors du Traitement de l'Action de Demande de Nom",
+      description: "Une erreur s'est produite lors du traitement de l'action de demande de nom. Veuillez réessayer."
+    },
     invalidFilingApplication: {
       title: '{type} Invalide',
       description: 'Vous ne pouvez pas ouvrir cette application car la Demande de Nom associée a expiré. Veuillez soumettre une nouvelle Demande de Nom et une {type}.'

--- a/business-registry-dashboard/app/utils/business.ts
+++ b/business-registry-dashboard/app/utils/business.ts
@@ -248,7 +248,7 @@ export async function createNamedBusiness ({ filingType, business }: { filingTyp
 
   // create an affiliation between implicit org and requested business
   // const response = await BusinessService.createDraftFiling(filingBody)
-  const response = await $fetch(`${legalApiUrl}/businesses?draft=true/test`, {
+  const response = await $fetch(`${legalApiUrl}/businesses?draft=true`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,

--- a/business-registry-dashboard/app/utils/business.ts
+++ b/business-registry-dashboard/app/utils/business.ts
@@ -248,7 +248,7 @@ export async function createNamedBusiness ({ filingType, business }: { filingTyp
 
   // create an affiliation between implicit org and requested business
   // const response = await BusinessService.createDraftFiling(filingBody)
-  const response = await $fetch(`${legalApiUrl}/businesses?draft=true`, {
+  const response = await $fetch(`${legalApiUrl}/businesses?draft=true/test`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/26607

Added error dialog when trying to perform an action like "Register Now" in the BRD (usually happens if Legal API failed to create a draft):

<img width="434" alt="image" src="https://github.com/user-attachments/assets/597df310-2630-4df6-876e-3d8f06717e24" />


~I just need to confirm the text with Jacqueline~ Design: https://www.figma.com/design/6MBqd7QAijpl6OXLvLXmos/Errors?node-id=89-71&p=f&m=dev