### PR TITLE
27067 - Fixed LD targetting + wrong user reporting

### DIFF
--- a/business-registry-dashboard/app/stores/connect-launchdarkly.ts
+++ b/business-registry-dashboard/app/stores/connect-launchdarkly.ts
@@ -1,9 +1,7 @@
 import { initialize } from 'launchdarkly-js-client-sdk'
 import type { LDClient, LDFlagSet, LDOptions, LDMultiKindContext } from 'launchdarkly-js-client-sdk'
-import { defineStore } from 'pinia'
-import { useKeycloak, useConnectAccountStore } from '#imports'
 
-export const useConnectLaunchdarklyStore = defineStore('brd-connect-ld-store', () => {
+export const useConnectLaunchdarklyStore = defineStore('nuxt-core-connect-ld-store', () => {
   const keycloak = reactive(useKeycloak())
   const accountStore = useConnectAccountStore()
   const ldClient: Ref<LDClient | null> = ref(null)
@@ -14,45 +12,31 @@ export const useConnectLaunchdarklyStore = defineStore('brd-connect-ld-store', (
   } as LDMultiKindContext)
   const ldFlagSet: Ref<LDFlagSet> = ref({})
   const ldInitialized = ref(false)
-  const isInitializing = ref(false)
-  const isAppLoaded = ref(false)
 
-  // Only initialize LaunchDarkly after app is fully loaded and user is authenticated
-  watch([() => keycloak.isAuthenticated, () => isAppLoaded.value], ([isAuthenticated, isLoaded]) => {
-    if (isAuthenticated && isLoaded && !ldInitialized.value && !isInitializing.value) {
-      init()
-    } else if (isAuthenticated && isLoaded && ldInitialized.value) {
-      // If the context has changed but we're already initialized, update the context
-      updateUserContext()
+  function init () {
+    if (ldInitialized.value) {
+      console.info('Launchdarkly already initialized.')
+      return
     }
-  })
-
-  // Watch for account changes to update LaunchDarkly org context
-  watch(() => accountStore.currentAccount.id, (accountId) => {
-    if (accountId && ldInitialized.value) {
-      updateUserContext()
+    const ldClientId = useRuntimeConfig().public.ldClientId
+    if (!ldClientId) {
+      console.info('No launchdarkly sdk variable set. Aborting launchdarkly setup.')
+      return
     }
-  })
-
-  // Create the user and org context objects for LaunchDarkly
-  function createLdContext () {
     const appName = useRuntimeConfig().public.appName
-
-    // Create user context
-    const user = {
-      key: keycloak.kcUser.keycloakGuid,
-      firstName: keycloak.kcUser.firstName,
-      lastName: keycloak.kcUser.lastName,
-      email: keycloak.kcUser.email || 'unknown@example.com', // Ensure email is never undefined
-      roles: keycloak.kcUser.roles,
-      loginSource: keycloak.kcUser.loginSource,
-      appSource: appName
+    let user: any = { key: 'anonymous', appSource: appName }
+    let org: any = { key: 'anonymous', appName }
+    if (keycloak.isAuthenticated) {
+      user = {
+        key: keycloak.kcUser.keycloakGuid,
+        firstName: keycloak.kcUser.firstName,
+        lastName: keycloak.kcUser.lastName,
+        email: keycloak.kcUser.email,
+        roles: keycloak.kcUser.roles,
+        loginSource: keycloak.kcUser.loginSource,
+        appSource: appName
+      }
     }
-
-    // Default org to user key if no account
-    let org = { key: user.key, appSource: appName }
-
-    // Use account info if available
     if (accountStore.currentAccount.id) {
       org = {
         key: accountStore.currentAccount.id,
@@ -63,69 +47,18 @@ export const useConnectLaunchdarklyStore = defineStore('brd-connect-ld-store', (
         appSource: appName
       }
     }
-
-    return { kind: 'multi', org, user } as LDMultiKindContext
-  }
-
-  function updateUserContext () {
-    if (!ldClient.value) { return }
-
-    // Create new context using shared function
-    const newContext = createLdContext()
-    ldContext.value = newContext
-
-    // Update the LaunchDarkly context
-    ldClient.value.identify(newContext).then(() => {
-      // Update flag values after context change
-      ldFlagSet.value = ldClient.value?.allFlags() || {}
-    }).catch((error) => {
-      console.error('LaunchDarkly context update error:', error)
-    })
-  }
-
-  function init () {
-    if (ldInitialized.value || isInitializing.value) {
-      return
-    }
-
-    // Skip initialization if user is not authenticated
-    if (!keycloak.isAuthenticated || !keycloak.kcUser?.keycloakGuid) {
-      return
-    }
-
-    isInitializing.value = true
-    const ldClientId = useRuntimeConfig().public.ldClientId
-    if (!ldClientId) {
-      isInitializing.value = false
-      return
-    }
-
-    // Create context using shared function
-    ldContext.value = createLdContext()
+    ldContext.value = { kind: 'multi', org, user }
     const options: LDOptions = {
       streaming: false,
       useReport: false,
       diagnosticOptOut: true
     }
-
-    try {
-      ldClient.value = initialize(ldClientId, ldContext.value, options)
-      ldClient.value.on('initialized', () => {
-        ldFlagSet.value = ldClient.value?.allFlags() || {}
-        ldInitialized.value = true
-        isInitializing.value = false
-        console.info('LaunchDarkly initialization complete.')
-      })
-
-      // Handle initialization failure
-      ldClient.value.on('error', (error) => {
-        console.error('LaunchDarkly initialization error:', error)
-        isInitializing.value = false
-      })
-    } catch (error) {
-      console.error('LaunchDarkly failed to initialize:', error)
-      isInitializing.value = false
-    }
+    ldClient.value = initialize(ldClientId, ldContext.value, options)
+    ldClient.value.on('initialized', () => {
+      ldFlagSet.value = ldClient.value?.allFlags() || {}
+      ldInitialized.value = true
+      console.info('launchdarkly initialization complete.')
+    })
   }
 
   function getFeatureFlag (name: string): any {
@@ -133,17 +66,24 @@ export const useConnectLaunchdarklyStore = defineStore('brd-connect-ld-store', (
   }
 
   function getStoredFlag (name: string): any {
+    if (!ldInitialized) {
+      console.warn('Accessing ldarkly stored flag, but ldarkly is not initialized.')
+    }
     return ldFlagSet.value[name]
   }
 
   function $reset () {
     ldInitialized.value = false
-    isInitializing.value = false
     ldClient.value = null
     ldFlagSet.value = {}
   }
 
   return {
+    ldClient,
+    ldContext,
+    ldFlagSet,
+    ldInitialized,
+    init,
     getFeatureFlag,
     getStoredFlag,
     $reset

--- a/business-registry-dashboard/app/stores/connect-launchdarkly.ts
+++ b/business-registry-dashboard/app/stores/connect-launchdarkly.ts
@@ -1,0 +1,195 @@
+import { initialize } from 'launchdarkly-js-client-sdk'
+import type { LDClient, LDFlagSet, LDOptions, LDMultiKindContext } from 'launchdarkly-js-client-sdk'
+import { defineStore } from 'pinia'
+import { useKeycloak, useConnectAccountStore } from '#imports'
+
+export const useConnectLaunchdarklyStore = defineStore('brd-connect-ld-store', () => {
+  const keycloak = reactive(useKeycloak())
+  const accountStore = useConnectAccountStore()
+  const ldClient: Ref<LDClient | null> = ref(null)
+  const ldContext = ref({
+    kind: 'multi',
+    org: { key: 'anonymous' },
+    user: { key: 'anonymous' }
+  } as LDMultiKindContext)
+  const ldFlagSet: Ref<LDFlagSet> = ref({})
+  const ldInitialized = ref(false)
+  const isInitializing = ref(false)
+  const isAppLoaded = ref(false)
+
+  // Only initialize LaunchDarkly after app is fully loaded and user is authenticated
+  watch([() => keycloak.isAuthenticated, () => isAppLoaded.value], ([isAuthenticated, isLoaded]) => {
+    if (isAuthenticated && isLoaded && !ldInitialized.value && !isInitializing.value) {
+      init()
+    } else if (isAuthenticated && isLoaded && ldInitialized.value) {
+      // If the context has changed but we're already initialized, update the context
+      updateUserContext()
+    }
+  })
+
+  // Watch for account changes to update LaunchDarkly org context
+  watch(() => accountStore.currentAccount.id, (accountId) => {
+    if (accountId && ldInitialized.value) {
+      updateUserContext()
+    }
+  })
+
+  function updateUserContext () {
+    if (!ldClient.value) { return }
+
+    // Only update context if user is authenticated
+    if (!keycloak.isAuthenticated || !keycloak.kcUser?.keycloakGuid) {
+      console.info('Not updating LaunchDarkly context - user not authenticated')
+      return
+    }
+
+    const appName = useRuntimeConfig().public.appName
+    const user = {
+      key: keycloak.kcUser.keycloakGuid,
+      firstName: keycloak.kcUser.firstName,
+      lastName: keycloak.kcUser.lastName,
+      email: keycloak.kcUser.email || 'unknown@example.com', // Ensure email is never undefined
+      roles: keycloak.kcUser.roles,
+      loginSource: keycloak.kcUser.loginSource,
+      appSource: appName
+    }
+
+    let org = { key: user.key, appSource: appName } // Default to user key if no account
+
+    if (accountStore.currentAccount.id) {
+      org = {
+        key: accountStore.currentAccount.id,
+        accountType: accountStore.currentAccount.accountType,
+        accountStatus: accountStore.currentAccount.accountStatus,
+        type: accountStore.currentAccount.type,
+        label: accountStore.currentAccount.label,
+        appSource: appName
+      }
+    }
+
+    const newContext = { kind: 'multi', org, user } as LDMultiKindContext
+    ldContext.value = newContext
+
+    // Update the LaunchDarkly context
+    ldClient.value.identify(newContext).then(() => {
+      // Update flag values after context change
+      ldFlagSet.value = ldClient.value?.allFlags() || {}
+      console.info('LaunchDarkly context updated successfully')
+    }).catch((error) => {
+      console.error('LaunchDarkly context update error:', error)
+    })
+  }
+
+  function init () {
+    console.info('Initializing LaunchDarkly')
+    if (ldInitialized.value) {
+      console.info('LaunchDarkly already initialized.')
+      return
+    }
+
+    // Prevent multiple initialization attempts
+    if (isInitializing.value) {
+      console.info('LaunchDarkly initialization already in progress.')
+      return
+    }
+
+    // Skip initialization if user is not authenticated
+    if (!keycloak.isAuthenticated || !keycloak.kcUser?.keycloakGuid) {
+      console.info('Not initializing LaunchDarkly - user not authenticated')
+      return
+    }
+
+    isInitializing.value = true
+
+    const ldClientId = useRuntimeConfig().public.ldClientId
+    if (!ldClientId) {
+      console.info('No LaunchDarkly SDK variable set. Aborting LaunchDarkly setup.')
+      isInitializing.value = false
+      return
+    }
+
+    const appName = useRuntimeConfig().public.appName
+
+    // Only initialize with authenticated user context
+    const user = {
+      key: keycloak.kcUser.keycloakGuid,
+      firstName: keycloak.kcUser.firstName,
+      lastName: keycloak.kcUser.lastName,
+      email: keycloak.kcUser.email || 'unknown@example.com', // Ensure email is never undefined
+      roles: keycloak.kcUser.roles,
+      loginSource: keycloak.kcUser.loginSource,
+      appSource: appName
+    }
+
+    // Default org to user key if no account selected
+    let org = { key: user.key, appSource: appName }
+
+    if (accountStore.currentAccount.id) {
+      org = {
+        key: accountStore.currentAccount.id,
+        accountType: accountStore.currentAccount.accountType,
+        accountStatus: accountStore.currentAccount.accountStatus,
+        type: accountStore.currentAccount.type,
+        label: accountStore.currentAccount.label,
+        appSource: appName
+      }
+    }
+
+    ldContext.value = { kind: 'multi', org, user }
+    const options: LDOptions = {
+      streaming: false,
+      useReport: false,
+      diagnosticOptOut: true
+    }
+
+    try {
+      ldClient.value = initialize(ldClientId, ldContext.value, options)
+
+      ldClient.value.on('initialized', () => {
+        ldFlagSet.value = ldClient.value?.allFlags() || {}
+        ldInitialized.value = true
+        isInitializing.value = false
+        console.info('LaunchDarkly initialization complete.')
+      })
+
+      // Handle initialization failure
+      ldClient.value.on('error', (error) => {
+        console.error('LaunchDarkly initialization error:', error)
+        isInitializing.value = false
+      })
+    } catch (error) {
+      console.error('LaunchDarkly failed to initialize:', error)
+      isInitializing.value = false
+    }
+  }
+
+  function getFeatureFlag (name: string): any {
+    return ldClient.value ? ldClient.value.variation(name) : null
+  }
+
+  function getStoredFlag (name: string): any {
+    if (!ldInitialized.value) {
+      console.warn('Accessing LaunchDarkly stored flag, but LaunchDarkly is not initialized.')
+    }
+    return ldFlagSet.value[name]
+  }
+
+  function $reset () {
+    ldInitialized.value = false
+    isInitializing.value = false
+    ldClient.value = null
+    ldFlagSet.value = {}
+  }
+
+  return {
+    ldClient,
+    ldContext,
+    ldFlagSet,
+    ldInitialized,
+    init,
+    getFeatureFlag,
+    getStoredFlag,
+    updateUserContext,
+    $reset
+  }
+})

--- a/business-registry-dashboard/app/stores/connect-launchdarkly.ts
+++ b/business-registry-dashboard/app/stores/connect-launchdarkly.ts
@@ -1,7 +1,9 @@
 import { initialize } from 'launchdarkly-js-client-sdk'
 import type { LDClient, LDFlagSet, LDOptions, LDMultiKindContext } from 'launchdarkly-js-client-sdk'
+import { defineStore } from 'pinia'
+import { useKeycloak, useConnectAccountStore } from '#imports'
 
-export const useConnectLaunchdarklyStore = defineStore('nuxt-core-connect-ld-store', () => {
+export const useConnectLaunchdarklyStore = defineStore('brd-connect-ld-store', () => {
   const keycloak = reactive(useKeycloak())
   const accountStore = useConnectAccountStore()
   const ldClient: Ref<LDClient | null> = ref(null)
@@ -12,31 +14,45 @@ export const useConnectLaunchdarklyStore = defineStore('nuxt-core-connect-ld-sto
   } as LDMultiKindContext)
   const ldFlagSet: Ref<LDFlagSet> = ref({})
   const ldInitialized = ref(false)
+  const isInitializing = ref(false)
+  const isAppLoaded = ref(false)
 
-  function init () {
-    if (ldInitialized.value) {
-      console.info('Launchdarkly already initialized.')
-      return
+  // Only initialize LaunchDarkly after app is fully loaded and user is authenticated
+  watch([() => keycloak.isAuthenticated, () => isAppLoaded.value], ([isAuthenticated, isLoaded]) => {
+    if (isAuthenticated && isLoaded && !ldInitialized.value && !isInitializing.value) {
+      init()
+    } else if (isAuthenticated && isLoaded && ldInitialized.value) {
+      // If the context has changed but we're already initialized, update the context
+      updateUserContext()
     }
-    const ldClientId = useRuntimeConfig().public.ldClientId
-    if (!ldClientId) {
-      console.info('No launchdarkly sdk variable set. Aborting launchdarkly setup.')
-      return
+  })
+
+  // Watch for account changes to update LaunchDarkly org context
+  watch(() => accountStore.currentAccount.id, (accountId) => {
+    if (accountId && ldInitialized.value) {
+      updateUserContext()
     }
+  })
+
+  // Create the user and org context objects for LaunchDarkly
+  function createLdContext () {
     const appName = useRuntimeConfig().public.appName
-    let user: any = { key: 'anonymous', appSource: appName }
-    let org: any = { key: 'anonymous', appName }
-    if (keycloak.isAuthenticated) {
-      user = {
-        key: keycloak.kcUser.keycloakGuid,
-        firstName: keycloak.kcUser.firstName,
-        lastName: keycloak.kcUser.lastName,
-        email: keycloak.kcUser.email,
-        roles: keycloak.kcUser.roles,
-        loginSource: keycloak.kcUser.loginSource,
-        appSource: appName
-      }
+
+    // Create user context
+    const user = {
+      key: keycloak.kcUser.keycloakGuid,
+      firstName: keycloak.kcUser.firstName,
+      lastName: keycloak.kcUser.lastName,
+      email: keycloak.kcUser.email,
+      roles: keycloak.kcUser.roles,
+      loginSource: keycloak.kcUser.loginSource,
+      appSource: appName
     }
+
+    // Default org to user key if no account
+    let org = { key: user.key, appSource: appName }
+
+    // Use account info if available
     if (accountStore.currentAccount.id) {
       org = {
         key: accountStore.currentAccount.id,
@@ -47,18 +63,69 @@ export const useConnectLaunchdarklyStore = defineStore('nuxt-core-connect-ld-sto
         appSource: appName
       }
     }
-    ldContext.value = { kind: 'multi', org, user }
+
+    return { kind: 'multi', org, user } as LDMultiKindContext
+  }
+
+  function updateUserContext () {
+    if (!ldClient.value) { return }
+
+    // Create new context using shared function
+    const newContext = createLdContext()
+    ldContext.value = newContext
+
+    // Update the LaunchDarkly context
+    ldClient.value.identify(newContext).then(() => {
+      // Update flag values after context change
+      ldFlagSet.value = ldClient.value?.allFlags() || {}
+    }).catch((error) => {
+      console.error('LaunchDarkly context update error:', error)
+    })
+  }
+
+  function init () {
+    if (ldInitialized.value || isInitializing.value) {
+      return
+    }
+
+    // Skip initialization if user is not authenticated
+    if (!keycloak.isAuthenticated || !keycloak.kcUser?.keycloakGuid) {
+      return
+    }
+
+    isInitializing.value = true
+    const ldClientId = useRuntimeConfig().public.ldClientId
+    if (!ldClientId) {
+      isInitializing.value = false
+      return
+    }
+
+    // Create context using shared function
+    ldContext.value = createLdContext()
     const options: LDOptions = {
       streaming: false,
       useReport: false,
       diagnosticOptOut: true
     }
-    ldClient.value = initialize(ldClientId, ldContext.value, options)
-    ldClient.value.on('initialized', () => {
-      ldFlagSet.value = ldClient.value?.allFlags() || {}
-      ldInitialized.value = true
-      console.info('launchdarkly initialization complete.')
-    })
+
+    try {
+      ldClient.value = initialize(ldClientId, ldContext.value, options)
+      ldClient.value.on('initialized', () => {
+        ldFlagSet.value = ldClient.value?.allFlags() || {}
+        ldInitialized.value = true
+        isInitializing.value = false
+        console.info('LaunchDarkly initialization complete.')
+      })
+
+      // Handle initialization failure
+      ldClient.value.on('error', (error) => {
+        console.error('LaunchDarkly initialization error:', error)
+        isInitializing.value = false
+      })
+    } catch (error) {
+      console.error('LaunchDarkly failed to initialize:', error)
+      isInitializing.value = false
+    }
   }
 
   function getFeatureFlag (name: string): any {
@@ -74,15 +141,12 @@ export const useConnectLaunchdarklyStore = defineStore('nuxt-core-connect-ld-sto
 
   function $reset () {
     ldInitialized.value = false
+    isInitializing.value = false
     ldClient.value = null
     ldFlagSet.value = {}
   }
 
   return {
-    ldClient,
-    ldContext,
-    ldFlagSet,
-    ldInitialized,
     init,
     getFeatureFlag,
     getStoredFlag,

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/27067

OK, here's a bit of info what I did here:

First and foremost, I moved the LD store out of the nuxt daxiom shared package. The store used to be here:
`business-ui\business-registry-dashboard\node_modules\@daxiom\nuxt-core-layer-test\app\stores`

Now, I don't know if Thor will like this but I needed to do that in order to make my own changes. The changes being correctly reporting the context to LD when an org/user is changed. 

- I added some additional `console.info` to see what's going on
- The context is updated and sent to LD on user/org change.

Here's how I tested:
I logged in as BCREG0020 which defaults to resd right. The contexts in LD are:
<img width="1106" alt="image" src="https://github.com/user-attachments/assets/233210a2-bdb5-4882-83f8-65d6fd27ee34" />
You can see up top 668 which is the org id for resd. 

Now, let's change the account to mine: 
<img width="312" alt="image" src="https://github.com/user-attachments/assets/0f299408-98ac-4da7-9848-b417d724a9e3" />

The event now is passed (previously this doesn't happen):
<img width="776" alt="image" src="https://github.com/user-attachments/assets/92af6685-6184-4ea1-9131-db651db43125" />

Now checking in LD after waiting a bit:
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/ce0dfc9e-6b75-4022-a6a8-762adbf8a8fe" />

As you can see, this org ID resembles my dev account in BCREG0020 that I just switched to.

Now finally, to test this, what I did is I enabled targeting for my org ID:
<img width="913" alt="image" src="https://github.com/user-attachments/assets/3eb8c1fd-6f91-4152-8063-7a93e8799076" />

And it works! You can see the pagination controls below.
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/c89cd505-a972-419d-8cf7-f62c6b6994bc" />
 
### NOTE: An Ad blocker prevents the app from relaying the contexts to LD. This is why we see sometimes anonymous in LD. Sev, Mihai had this issue at one point if you remember and we were wondering why. This might've been it. The ad blocker MUST be disabled to report back correctly to LD.