### PR TITLE
added extraprovincial companies to server side type filtering

### DIFF
--- a/business-registry-dashboard/app/enums/display-name-to-corp-type.ts
+++ b/business-registry-dashboard/app/enums/display-name-to-corp-type.ts
@@ -19,5 +19,6 @@ export const DisplayNameToCorpType: Record<string, string> = {
   'Incorporation Application': CorpTypes.INCORPORATION_APPLICATION,
   'Amalgamation Application': CorpTypes.AMALGAMATION_APPLICATION,
   Registration: CorpTypes.REGISTRATION,
-  'Continuation Application': CorpTypes.CONTINUE_IN
+  'Continuation Application': CorpTypes.CONTINUE_IN,
+  'Extraprovincial Company': CorpTypeCd.EXTRA_PRO_A
 }

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
I don't have a ticket for this so I'm just going to put Rajan's ticket https://github.com/bcgov/entity/issues/27148

https://auth-api-dev-142173140222.northamerica-northeast1.run.app/api/v1/orgs/3040/affiliations?new=true&type=Extraprovincial%20Company&page=1&limit=100

is now

https://auth-api-dev-142173140222.northamerica-northeast1.run.app/api/v1/orgs/3040/affiliations?new=true&type=A&page=1&limit=100