### PR TITLE
Officer reactivity address bug

### DIFF
--- a/web/person-roles/app/components/Form/OfficerChange/index.vue
+++ b/web/person-roles/app/components/Form/OfficerChange/index.vue
@@ -174,17 +174,20 @@ watch(
   () => state.sameAsDelivery,
   (v) => {
     if (v) {
-      state.mailingAddress = state.deliveryAddress
-      const mailingFields = [
-        'mailingAddress.city',
-        'mailingAddress.region',
-        'mailingAddress.postalCode',
-        'mailingAddress.street'
-      ]
-      mailingFields.forEach(item => formRef.value?.clear(item))
+      state.mailingAddress = { ...state.deliveryAddress }
     } else {
       state.mailingAddress = { ...props.defaultState.mailingAddress }
     }
+
+    const mailingFields = [
+      'mailingAddress.country',
+      'mailingAddress.city',
+      'mailingAddress.region',
+      'mailingAddress.postalCode',
+      'mailingAddress.street'
+    ]
+
+    mailingFields.forEach(item => formRef.value?.clear(item))
   },
   { immediate: true }
 )

--- a/web/person-roles/app/components/Form/OfficerChange/index.vue
+++ b/web/person-roles/app/components/Form/OfficerChange/index.vue
@@ -60,24 +60,18 @@ const addressSchema = z.object({
   const country = data.country
   const region = data.region
 
-  if (country === 'US' || country === 'CA') {
-    if (region && region.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: t('validation.fieldRequired'),
-        path: ['region']
-      })
-    } else if (region && region.length > 2) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: t('validation.maxChars', { count: 2 }),
-        path: ['region']
-      })
-    }
-  } else if (region && region.length > 2) {
+  if (region && region.length > 2) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: t('validation.maxChars', { count: 2 }),
+      path: ['region']
+    })
+  }
+
+  if ((country === 'US' || country === 'CA') && region?.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: t('validation.fieldRequired'),
       path: ['region']
     })
   }
@@ -189,7 +183,7 @@ watch(
       ]
       mailingFields.forEach(item => formRef.value?.clear(item))
     } else {
-      state.mailingAddress = props.defaultState.mailingAddress
+      state.mailingAddress = { ...props.defaultState.mailingAddress }
     }
   },
   { immediate: true }

--- a/web/person-roles/package.json
+++ b/web/person-roles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "person-roles",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
bcGov/entity#27631

- fix reactivity between mailing/delivery address when selecting sameAsDelivery checkbox
- remove redundant if/else in region schema
- add 'mailingAddress.country' to list of fields to clear when sameAs checkbox selected