### PR TITLE
27629 - Fixed text filtering bug + put minimum characters

### DIFF
--- a/business-registry-dashboard/app/stores/affiliations.ts
+++ b/business-registry-dashboard/app/stores/affiliations.ts
@@ -42,7 +42,7 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
 
   // Helper function to check if filters have minimum required characters
   function hasMinimumFilterCharacters (filters: { businessName: string, businessNumber: string }): boolean {
-    return filters.businessName.length >= 2 ||
+    return filters.businessName.length >= 3 ||
            filters.businessNumber.length >= 2 ||
            (filters.businessName.length === 0 && filters.businessNumber.length === 0)
   }
@@ -371,7 +371,9 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
 
       // Only call loadAffiliations when server-side filtering is enabled
       if (enableServerFiltering.value) {
-        // Only trigger search when there are at least 2 characters (or 0 to reset)
+        // Only trigger search when there are at least 3 characters for business name
+        // 2 characters for business number
+        // or 0 characters for both to reset
         const hasMinimumCharacters = hasMinimumFilterCharacters(affiliations.filters)
 
         if (hasMinimumCharacters) {

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/27629

Sev found a bug. Let's say you type NR4 and then the table starts loading. While the table is loading, if you type x after 4, the results will still be for NR4 which is very bad user experience honestly and will be probably frustrating for users. This PR fixes this. 

I also added a minimum requirement for how many characters is needed. Sev, please if you can test the bug in the temp link, that would be great. Thanks.