### PR TITLE
27567 - Alert when using non-approved NRs to create business

### DIFF
--- a/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
+++ b/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
@@ -47,7 +47,7 @@ async function createBusinessRecord (business: Business): Promise<string> {
   const continuationInTypes = ldStore.getStoredFlag(LDFlags.SupportedContinuationInEntities)?.split(' ') || []
   const supportedIaRegTypes = ldStore.getStoredFlag(LDFlags.IaSupportedEntitiesBrd)?.split(' ') || []
 
-  // Check if name request approoved status has changed by refreshing its details
+  // Check if name request approved status has changed by refreshing its details
   if (business.nameRequest?.nrNumber) {
     try {
       const refreshedNR = await fetchNameRequest(business.nameRequest.nrNumber, business.nameRequest.applicantPhone as string, business.nameRequest.applicantEmail as string)

--- a/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
+++ b/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
@@ -47,6 +47,21 @@ async function createBusinessRecord (business: Business): Promise<string> {
   const continuationInTypes = ldStore.getStoredFlag(LDFlags.SupportedContinuationInEntities)?.split(' ') || []
   const supportedIaRegTypes = ldStore.getStoredFlag(LDFlags.IaSupportedEntitiesBrd)?.split(' ') || []
 
+  // Check if name request approoved status has changed by refreshing its details
+  if (business.nameRequest?.nrNumber) {
+    try {
+      const refreshedNR = await fetchNameRequest(business.nameRequest.nrNumber, business.nameRequest.applicantPhone as string, business.nameRequest.applicantEmail as string)
+      if (refreshedNR.state !== NrState.APPROVED) {
+        // Name request status is not approved, cannot create business
+        brdModal.openInvalidNameRequest()
+        return ''
+      }
+    } catch (error) {
+      console.warn('Could not refresh name request details:', error)
+      // Continue with creation attempt - the business dashboard ui will handle any conflicts
+    }
+  }
+
   let filingResponse: BusinessResponse | null = null
   let payload = null
   // If Incorporation or Registration

--- a/business-registry-dashboard/app/composables/useBrdModals.ts
+++ b/business-registry-dashboard/app/composables/useBrdModals.ts
@@ -77,7 +77,7 @@ export const useBrdModals = () => {
         description: t('error.invalidNameRequest.description')
       },
       actions: [
-        { label: t('btn.close'), handler: () => close() },
+        { label: t('btn.close'), variant: 'outline', handler: () => close() },
         { label: t('btn.refreshTable'), handler: () => { useAffiliationsStore().loadAffiliations(); close() } }
       ]
     })

--- a/business-registry-dashboard/app/composables/useBrdModals.ts
+++ b/business-registry-dashboard/app/composables/useBrdModals.ts
@@ -70,6 +70,19 @@ export const useBrdModals = () => {
     })
   }
 
+  function openInvalidNameRequest () {
+    modal.open(ModalBase, {
+      error: {
+        title: t('error.invalidNameRequest.title'),
+        description: t('error.invalidNameRequest.description')
+      },
+      actions: [
+        { label: t('btn.close'), handler: () => close() },
+        { label: t('btn.refreshTable'), handler: () => { useAffiliationsStore().loadAffiliations(); close() } }
+      ]
+    })
+  }
+
   function openBusinessUnavailableError (action: string) {
     let title: string
     let description: string
@@ -119,6 +132,7 @@ export const useBrdModals = () => {
     nameRequestActionError,
     openBusinessUnavailableError,
     openInvalidFilingApplication,
+    openInvalidNameRequest,
     openBusinessRemovalConfirmation,
     openManageBusiness,
     openMagicLinkModal,

--- a/business-registry-dashboard/app/locales/en-CA.ts
+++ b/business-registry-dashboard/app/locales/en-CA.ts
@@ -198,7 +198,7 @@ export default {
     },
     invalidNameRequest: {
       title: 'Invalid Name Request',
-      description: 'The status of this name request has changed. Please refresh the table and try again.'
+      description: 'The status of this name request has changed. Please refresh the table.'
     },
     magicLinkUnauthorized: {
       title: 'Unable to Manage Business',

--- a/business-registry-dashboard/app/locales/en-CA.ts
+++ b/business-registry-dashboard/app/locales/en-CA.ts
@@ -196,6 +196,10 @@ export default {
       title: 'Invalid {type}',
       description: 'You cannot open this application because the associated Name Request has expired. Please submit a new Name Request and {type}.'
     },
+    invalidNameRequest: {
+      title: 'Invalid Name Request',
+      description: 'The status of this name request has changed. Please refresh the table and try again.'
+    },
     magicLinkUnauthorized: {
       title: 'Unable to Manage Business',
       description: 'The account that requested authorisation does not match your current account. Please log in as the account that initiated the request.'

--- a/business-registry-dashboard/app/locales/fr-CA.ts
+++ b/business-registry-dashboard/app/locales/fr-CA.ts
@@ -188,7 +188,7 @@ export default {
     },
     invalidNameRequest: {
       title: 'Demande de Nom Invalide',
-      description: 'Le statut de cette demande de nom a changé. Veuillez rafraîchir le tableau et réessayer.'
+      description: 'Le statut de cette demande de nom a changé. Veuillez rafraîchir le tableau.'
     },
     magicLinkUnauthorized: {
       title: 'Impossible De Gérer L\'entreprise',

--- a/business-registry-dashboard/app/locales/fr-CA.ts
+++ b/business-registry-dashboard/app/locales/fr-CA.ts
@@ -186,6 +186,10 @@ export default {
       title: '{type} Invalide',
       description: 'Vous ne pouvez pas ouvrir cette application car la Demande de Nom associée a expiré. Veuillez soumettre une nouvelle Demande de Nom et une {type}.'
     },
+    invalidNameRequest: {
+      title: 'Demande de Nom Invalide',
+      description: 'Le statut de cette demande de nom a changé. Veuillez rafraîchir le tableau et réessayer.'
+    },
     magicLinkUnauthorized: {
       title: 'Impossible De Gérer L\'entreprise',
       description: 'Le compte qui a demandé l\'autorisation ne correspond pas à votre compte actuel. Veuillez vous connecter avec le compte qui a initié la demande.'

--- a/business-registry-dashboard/package.json
+++ b/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/27567

**EXAMPLE SCENARIO:**
I have two tabs open with a name request that's approved. I create a draft business in one tab and go all the way to completion. Now in tab number two, if I click on the register now button, we show an alert. This is since the NR is now consumed. This can happen for other situations like the NR expiring for example. 

![image](https://github.com/user-attachments/assets/74c600b2-f8fe-4920-b9db-950c9e2202fb)

I got the greenlight for the design of the dialog from Jacqueline. She's OK with this. 