### PR TITLE
28976 - Changed pagination controls + use isMore flag + misc. fixes

### DIFF
--- a/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
+++ b/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 const brdModal = useBrdModals()
 const affStore = useAffiliationsStore()
+const ldStore = useConnectLaunchdarklyStore()
 
 onMounted(async () => {
   await affStore.loadAffiliations()
@@ -53,7 +54,10 @@ const mapDetailsWithEffectiveDate = (details: any[], row: any) => {
   <SbcPageSectionCard>
     <template #header-left>
       <h2 class="text-base font-normal">
-        <ConnectI18nBold translation-path="labels.myList" :count="affStore.affiliations.count" />
+        <template v-if="ldStore.ldInitialized">
+          <ConnectI18nBold v-if="!affStore.enablePagination" translation-path="labels.myList" :count="affStore.affiliations.count" />
+          <ConnectI18nBold v-else translation-path="labels.myListWithPagination" />
+        </template>
       </h2>
     </template>
     <!-- columns to show dropdown -->
@@ -490,19 +494,24 @@ const mapDetailsWithEffectiveDate = (details: any[], row: any) => {
 
         <div class="flex items-center">
           <span class="mr-4 text-sm text-bcGovColor-midGray">
-            {{ $t('pagination.showing', {
-              start: ((affStore.affiliations.pagination.page - 1) * affStore.affiliations.pagination.limit) + 1,
-              end: Math.min(affStore.affiliations.pagination.page * affStore.affiliations.pagination.limit, affStore.affiliations.totalResults),
-              total: affStore.affiliations.totalResults
-            }) }}
+            {{ $t('pagination.page', { page: affStore.affiliations.pagination.page }) }}
           </span>
-          <UPagination
-            v-model="affStore.affiliations.pagination.page"
-            :total="affStore.affiliations.totalResults"
-            :page-count="affStore.affiliations.pagination.limit"
-            :max="6"
-            :disabled="affStore.affiliations.loading"
-          />
+          <div class="flex items-center gap-2">
+            <UButton
+              icon="i-mdi-chevron-left"
+              :disabled="affStore.affiliations.pagination.page === 1 || affStore.affiliations.loading"
+              variant="outline"
+              size="sm"
+              @click="affStore.goToPreviousPage()"
+            />
+            <UButton
+              icon="i-mdi-chevron-right"
+              :disabled="!affStore.affiliations.hasMore || affStore.affiliations.loading"
+              variant="outline"
+              size="sm"
+              @click="affStore.goToNextPage()"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
+++ b/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
@@ -498,14 +498,14 @@ const mapDetailsWithEffectiveDate = (details: any[], row: any) => {
           </span>
           <div class="flex items-center gap-2">
             <UButton
-              icon="i-mdi-chevron-left"
+              icon="i-heroicons-chevron-left-20-solid"
               :disabled="affStore.affiliations.pagination.page === 1 || affStore.affiliations.loading"
               variant="outline"
               size="sm"
               @click="affStore.goToPreviousPage()"
             />
             <UButton
-              icon="i-mdi-chevron-right"
+              icon="i-heroicons-chevron-right-20-solid"
               :disabled="!affStore.affiliations.hasMore || affStore.affiliations.loading"
               variant="outline"
               size="sm"

--- a/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
+++ b/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
@@ -500,14 +500,16 @@ const mapDetailsWithEffectiveDate = (details: any[], row: any) => {
             <UButton
               icon="i-heroicons-chevron-left-20-solid"
               :disabled="affStore.affiliations.pagination.page === 1 || affStore.affiliations.loading"
-              variant="outline"
+              :variant="(affStore.affiliations.pagination.page === 1 || affStore.affiliations.loading) ? 'soft' : 'outline'"
+              :class="affStore.affiliations.pagination.page === 1 || affStore.affiliations.loading ? 'text-gray-400' : ''"
               size="sm"
               @click="affStore.goToPreviousPage()"
             />
             <UButton
               icon="i-heroicons-chevron-right-20-solid"
               :disabled="!affStore.affiliations.hasMore || affStore.affiliations.loading"
-              variant="outline"
+              :variant="(!affStore.affiliations.hasMore || affStore.affiliations.loading) ? 'soft' : 'outline'"
+              :class="!affStore.affiliations.hasMore || affStore.affiliations.loading ? 'text-gray-400' : ''"
               size="sm"
               @click="affStore.goToNextPage()"
             />

--- a/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
+++ b/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
@@ -33,6 +33,15 @@ watch(
   { immediate: true }
 )
 
+// Computed properties for pagination button states
+const isPreviousDisabled = computed(() =>
+  affStore.affiliations.pagination.page === 1 || affStore.affiliations.loading
+)
+
+const isNextDisabled = computed(() =>
+  !affStore.affiliations.hasMore || affStore.affiliations.loading
+)
+
 /**
  * This function transforms alert details, handling two important cases:
  * 1. For FUTURE_EFFECTIVE alerts: Converts the simple enum value to a complex object with date info
@@ -499,17 +508,17 @@ const mapDetailsWithEffectiveDate = (details: any[], row: any) => {
           <div class="flex items-center gap-2">
             <UButton
               icon="i-heroicons-chevron-left-20-solid"
-              :disabled="affStore.affiliations.pagination.page === 1 || affStore.affiliations.loading"
-              :variant="(affStore.affiliations.pagination.page === 1 || affStore.affiliations.loading) ? 'soft' : 'outline'"
-              :class="affStore.affiliations.pagination.page === 1 || affStore.affiliations.loading ? 'text-gray-400' : ''"
+              :disabled="isPreviousDisabled"
+              :variant="isPreviousDisabled ? 'soft' : 'outline'"
+              :class="isPreviousDisabled ? 'text-gray-400' : ''"
               size="sm"
               @click="affStore.goToPreviousPage()"
             />
             <UButton
               icon="i-heroicons-chevron-right-20-solid"
-              :disabled="!affStore.affiliations.hasMore || affStore.affiliations.loading"
-              :variant="(!affStore.affiliations.hasMore || affStore.affiliations.loading) ? 'soft' : 'outline'"
-              :class="!affStore.affiliations.hasMore || affStore.affiliations.loading ? 'text-gray-400' : ''"
+              :disabled="isNextDisabled"
+              :variant="isNextDisabled ? 'soft' : 'outline'"
+              :class="isNextDisabled ? 'text-gray-400' : ''"
               size="sm"
               @click="affStore.goToNextPage()"
             />

--- a/web/business-registry-dashboard/app/interfaces/affiliation.ts
+++ b/web/business-registry-dashboard/app/interfaces/affiliation.ts
@@ -93,6 +93,8 @@ export interface NameRequestResponse {
 
 export interface AffiliationsResponse {
   entities: AffiliationResponse[]
+  hasMore?: boolean
+  totalResults?: number
 }
 
 export interface AffiliationFilterParams {

--- a/web/business-registry-dashboard/app/locales/en-CA.ts
+++ b/web/business-registry-dashboard/app/locales/en-CA.ts
@@ -526,6 +526,7 @@ export default {
     type: 'Type',
     actions: 'Actions',
     myList: '{boldStart}My List{boldEnd} ({count})',
+    myListWithPagination: '{boldStart}My List{boldEnd}',
     amalgamateNow: 'Amalgamate Now',
     alterNow: 'Alter Now',
     changeNameNow: 'Change Name Now',
@@ -904,6 +905,7 @@ export default {
   },
   pagination: {
     itemsPerPage: 'Items per page',
-    showing: 'Showing {start} to {end} of {total} items'
+    showing: 'Showing {start} to {end} of {total} items',
+    page: 'Page {page}'
   }
 }

--- a/web/business-registry-dashboard/app/locales/fr-CA.ts
+++ b/web/business-registry-dashboard/app/locales/fr-CA.ts
@@ -516,6 +516,7 @@ export default {
     type: 'Taper',
     actions: 'Actions',
     myList: '{boldStart}Ma liste{boldEnd} ({count})',
+    myListWithPagination: '{boldStart}Ma liste{boldEnd}',
     amalgamateNow: 'Fusionner Maintenant',
     alterNow: 'Modifier Maintenant',
     changeNameNow: 'Changer de Nom Maintenant',
@@ -894,6 +895,7 @@ export default {
   },
   pagination: {
     itemsPerPage: 'Éléments par page',
-    showing: 'Affichage de {start} à {end} sur {total} éléments'
+    showing: 'Affichage de {start} à {end} sur {total} éléments',
+    page: 'Page {page}'
   }
 }

--- a/web/business-registry-dashboard/app/stores/connect-launchdarkly.ts
+++ b/web/business-registry-dashboard/app/stores/connect-launchdarkly.ts
@@ -150,6 +150,7 @@ export const useConnectLaunchdarklyStore = defineStore('brd-connect-ld-store', (
     init,
     getFeatureFlag,
     getStoredFlag,
+    ldInitialized: readonly(ldInitialized),
     $reset
   }
 })

--- a/web/business-registry-dashboard/package.json
+++ b/web/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/28976

Changes:
- No more all the page numbers. We can only go left and right.
- Show the page we're at RIGHT NOW.
- Go left and right buttons
- My list doesn't have the count now (if pagination is enabled)
- We can go right only if the hasMore flag is true. 
- Fixed some small bugs (make the right call when page limit is change while we're not on page 1)