### PR TITLE
29145 - Reset page when account is changed + fixed magic link processing

### DIFF
--- a/web/business-registry-dashboard/app/composables/useMagicLinkProcessing.ts
+++ b/web/business-registry-dashboard/app/composables/useMagicLinkProcessing.ts
@@ -58,8 +58,9 @@ export function useMagicLinkProcessing () {
    */
   const processMagicLink = async (config: MagicLinkConfig) => {
     try {
-      // Check if the current account has an active subscription to BRD. If not, stop processing
-      if (!affStore.isSubscribed) {
+      // Load and check if the current account has an active subscription to BRD. If not, stop processing
+      await affStore.loadSubscriptionStatus()
+      if (affStore.isSubscribed !== true) {
         return
       }
 

--- a/web/business-registry-dashboard/app/layouts/dashboard.vue
+++ b/web/business-registry-dashboard/app/layouts/dashboard.vue
@@ -69,7 +69,7 @@ onMounted(async () => {
 
   // Load and check if the current account has an active subscription to the business registry dashboard
   await affStore.loadSubscriptionStatus()
-  if (!affStore.isSubscribed) {
+  if (affStore.isSubscribed !== true) {
     brdModal.openNoSubscriptionModal()
   }
 })

--- a/web/business-registry-dashboard/app/stores/affiliations.ts
+++ b/web/business-registry-dashboard/app/stores/affiliations.ts
@@ -32,7 +32,7 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
     error: false
   })
 
-  const isSubscribed = ref(false)
+  const isSubscribed = ref<boolean | null>(null)
 
   // Track if filters changed during loading
   const filtersChangedDuringLoading = ref(false)
@@ -826,8 +826,11 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
   }
 
   async function loadSubscriptionStatus () {
-    const hasActiveSubscription = await hasActiveBusinessRegistryDashboardSubscription(accountStore.currentAccount.id)
-    isSubscribed.value = hasActiveSubscription
+    // Only make the API call if subscription status hasn't been loaded yet
+    if (isSubscribed.value === null) {
+      const hasActiveSubscription = await hasActiveBusinessRegistryDashboardSubscription(accountStore.currentAccount.id)
+      isSubscribed.value = hasActiveSubscription
+    }
   }
 
   function $reset () {

--- a/web/business-registry-dashboard/app/stores/affiliations.ts
+++ b/web/business-registry-dashboard/app/stores/affiliations.ts
@@ -347,16 +347,26 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
     }
   }
 
-  // Watch for changes to account, feature flags, and pagination page
+  // Watch for account changes - reset page and load
+  watch(
+    () => accountStore.currentAccount.id,
+    async () => {
+      // Reset to page 1 when account changes
+      affiliations.pagination.page = 1
+      if (!affiliations.loading) {
+        await loadAffiliations()
+      }
+    },
+    { immediate: true }
+  )
+
+  // Watch for feature flag changes
   watch(
     [
-      () => accountStore.currentAccount.id,
       () => enableServerFiltering.value,
-      () => enablePagination.value,
-      () => affiliations.pagination.page
+      () => enablePagination.value
     ],
     async () => {
-      // Always call loadAffiliations for account and pagination changes
       if (!affiliations.loading) {
         await loadAffiliations()
       }
@@ -364,13 +374,22 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
     { deep: true }
   )
 
-  // Watch for changes to pagination limit.
+  // Watch for pagination page changes (excluding account changes)
+  watch(
+    () => affiliations.pagination.page,
+    async () => {
+      if (!affiliations.loading) {
+        await loadAffiliations()
+      }
+    }
+  )
+
+  // Watch for pagination limit changes
   watch(
     () => affiliations.pagination.limit,
     async () => {
       // Reset to page 1 when limit changes
       affiliations.pagination.page = 1
-      // call loadAffiliations when limit changes on page 1
       if (!affiliations.loading) {
         await loadAffiliations()
       }

--- a/web/business-registry-dashboard/package.json
+++ b/web/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/29145 and https://github.com/bcgov/entity/issues/29148

I'm changing my account from resd to Karim Dev account while I was on page 2. The call was still being made to page 2 and the table was showing empty.

I have a handful of stuff in Karim Dev Account so that's why. This can be very misleading to users.

We now reset to page 1 on account switching.



Mihai was telling me that magic links weren't being processed at all and he was right. I fixed that here as well.