### PR TITLE
29159 - Auth API numbered draft businesses should not display with a NR number

### DIFF
--- a/web/business-registry-dashboard/app/stores/affiliations.ts
+++ b/web/business-registry-dashboard/app/stores/affiliations.ts
@@ -60,13 +60,11 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
 
   // Flag for whether server-side filtering is enabled
   const enableServerFiltering = computed(() =>
-    ldStore.getStoredFlag(LDFlags.EnableAffiliationsServerFiltering) || false
-  )
+true  )
 
   // Flag for whether pagination is enabled
   const enablePagination = computed(() =>
-    ldStore.getStoredFlag(LDFlags.EnableAffiliationsPagination) || false
-  )
+true  )
 
   const newlyAddedIdentifier = ref<string>('')
 
@@ -279,12 +277,14 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
       let affiliatedEntities: Business[] = []
 
       if (response.entities.length > 0) {
+        console.log("in responses entities", response.entities)
         response.entities.forEach((resp) => {
           const entity: Business = buildBusinessObject(resp)
           if (resp.nameRequest) {
+            console.log("in responses entities nameRequest", entity.nrNumber)
             const nr = resp.nameRequest
             if (!entity.nrNumber && nr.nrNum) {
-              entity.nrNumber = entity.nrNumber || nr.nrNum
+              entity.nrNumber = "test"
             }
             entity.nameRequest = buildNameRequestObject(nr)
           }

--- a/web/business-registry-dashboard/app/stores/affiliations.ts
+++ b/web/business-registry-dashboard/app/stores/affiliations.ts
@@ -60,11 +60,13 @@ export const useAffiliationsStore = defineStore('brd-affiliations-store', () => 
 
   // Flag for whether server-side filtering is enabled
   const enableServerFiltering = computed(() =>
-true  )
+    ldStore.getStoredFlag(LDFlags.EnableAffiliationsServerFiltering) || false
+  )
 
   // Flag for whether pagination is enabled
   const enablePagination = computed(() =>
-true  )
+    ldStore.getStoredFlag(LDFlags.EnableAffiliationsPagination) || false
+  )
 
   const newlyAddedIdentifier = ref<string>('')
 
@@ -277,11 +279,9 @@ true  )
       let affiliatedEntities: Business[] = []
 
       if (response.entities.length > 0) {
-        console.log("in responses entities", response.entities)
         response.entities.forEach((resp) => {
           const entity: Business = buildBusinessObject(resp)
           if (resp.nameRequest) {
-            console.log("in responses entities nameRequest", entity.nrNumber)
             const nr = resp.nameRequest
             if (!entity.nrNumber && nr.nrNum) {
               entity.nrNumber = entity.nrNumber || nr.nrNum

--- a/web/business-registry-dashboard/app/stores/affiliations.ts
+++ b/web/business-registry-dashboard/app/stores/affiliations.ts
@@ -284,7 +284,7 @@ true  )
             console.log("in responses entities nameRequest", entity.nrNumber)
             const nr = resp.nameRequest
             if (!entity.nrNumber && nr.nrNum) {
-              entity.nrNumber = "test"
+              entity.nrNumber = entity.nrNumber || nr.nrNum
             }
             entity.nameRequest = buildNameRequestObject(nr)
           }

--- a/web/business-registry-dashboard/app/utils/affiliations.ts
+++ b/web/business-registry-dashboard/app/utils/affiliations.ts
@@ -301,7 +301,7 @@ export const isNumberedIncorporationApplication = (item: Business): boolean => {
 // /** Returns the identifier of the affiliation. */
 export const number = (business: Business): string => {
   if (isTemporaryBusiness(business) || isNameRequest(business)) {
-    return business.nameRequest?.nrNumber || business.nrNumber || ''
+    return business.nameRequest?.nrNumber || ''
   }
   return business.businessIdentifier
 }

--- a/web/business-registry-dashboard/package.json
+++ b/web/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
Issue: 
[/bcgov/enitity#29159](https://github.com/bcgov/entity/issues/29159)

Description:

Auth API: numbered draft businesses should not display with a NR number

Changes:
 - Removed nrNumber to bring as an identifier for affiliation