### PR TITLE
29432 officers fix has changes

### DIFF
--- a/web/person-roles/app/components/Form/OfficerChange/index.vue
+++ b/web/person-roles/app/components/Form/OfficerChange/index.vue
@@ -269,6 +269,16 @@ watch(
   }
 )
 
+// reset preferred name field if user unselects checkbox
+watch(
+  () => state.hasPreferredName,
+  (v) => {
+    if (!v) {
+      state.preferredName = ''
+    }
+  }
+)
+
 // handle unfinished task warnings
 const unfinishedTaskMsg = ref('')
 na.hook('app:officer-form:incomplete', async (payload) => {

--- a/web/person-roles/app/pages/officer-change/[businessId].vue
+++ b/web/person-roles/app/pages/officer-change/[businessId].vue
@@ -58,7 +58,7 @@ feeStore.fees = {
 // TODO: how to not run this if the users sessions was expired, save draft automatically? ignore changes and logout?
 // show browser error if unsaved changes
 function onBeforeUnload(event: BeforeUnloadEvent) {
-  if (officerStore.hasChanges) {
+  if (officerStore.checkHasChanges('save')) {
     event.preventDefault()
     // legacy browsers
     event.returnValue = true
@@ -93,10 +93,11 @@ async function submitFiling() {
     }
 
     // prevent submit if there are no changes
-    if (!officerStore.hasChanges && !officerStore.officerDraftTableState.length) {
+    if (!officerStore.checkHasChanges('submit')) {
       setAlertText(false, 'right', t('text.noChangesToSubmit'))
       return
     }
+
     // set submit button as loading, disable all other bottom buttons
     handleButtonLoading(false, 'right', 1)
 
@@ -160,7 +161,7 @@ async function submitFiling() {
 }
 
 async function cancelFiling() {
-  if (officerStore.hasChanges) {
+  if (officerStore.checkHasChanges('save')) {
     await modal.openBaseModal(
       t('modal.unsavedChanges.title'),
       t('modal.unsavedChanges.description'),
@@ -198,7 +199,7 @@ async function saveFiling(resumeLater = false, disableActiveFormCheck = false) {
   }
 
   // prevent save if there are no changes
-  if (!officerStore.hasChanges) {
+  if (!officerStore.checkHasChanges('save')) {
     setAlertText(false, 'left', t('text.noChangesToSave'))
     return
   }

--- a/web/person-roles/tests/e2e/setup.ts
+++ b/web/person-roles/tests/e2e/setup.ts
@@ -50,6 +50,12 @@ async function globalSetup() {
   await page.getByLabel('Email or username').fill(username)
   await page.getByLabel('Password').fill(password)
   await page.getByRole('button', { name: 'Continue' }).click()
+  // necessary after sign in change
+  const agreeToTerms = page.getByText('I agree to the BC Login')
+  if (agreeToTerms) {
+    await agreeToTerms.click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+  }
 
   // should be redirected back to baseUrl after successful login
   await page.waitForURL(baseUrl + '**')

--- a/web/person-roles/tests/e2e/specs/example.spec.ts
+++ b/web/person-roles/tests/e2e/specs/example.spec.ts
@@ -7,7 +7,8 @@ test.describe('Example', () => {
 
   test('Passes', async ({ page }) => {
     await page.goto('./')
-    await expect(page.getByText('TBD')).toBeVisible()
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('Officer Change').first()).toBeVisible()
     await scanA11y(page)
   })
 })


### PR DESCRIPTION
*Issue #:* bcgov/entity#29432

*Description of changes:*
- fix has changes check on save and submit
- fix auth setup in e2e
- reset preferredName field when unselecting 'user has a preferred name' checkbox

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
