### PR TITLE
29290 - and UX comments cleanup

### DIFF
--- a/web/post-restoration-transition-application/app/components/Form/Certify.vue
+++ b/web/post-restoration-transition-application/app/components/Form/Certify.vue
@@ -10,10 +10,6 @@ const props = defineProps<{
 }>()
 
 const t = useNuxtApp().$i18n.t
-
-const displayLegalName = computed(() => {
-  return props.legalName || t('text.legalNameCertifyPlaceHolder')
-})
 </script>
 
 <template>
@@ -27,16 +23,27 @@ const displayLegalName = computed(() => {
       <template #label>
         <div class="flex flex-col text-base space-y-2">
           <div :class="{ 'text-red-500': hasError }">
-            <p>
-              <span class="font-bold">{{ displayLegalName }}</span>
-              {{ $t('text.certifiesItHasRelevantKnowledge', { legalName: displayLegalName }) }}
-            </p>
+            <slot name="certifyText">
+              <i18n-t
+                keypath="text.certifiesItHasRelevantKnowledgeClient"
+                tag="p"
+                class="mt-[-2px]"
+              >
+                <template #legalName>
+                  <strong>{{ legalName }}</strong>
+                </template>
+              </i18n-t>
+            </slot>
           </div>
           <div>
-            <span class="font-bold">{{ $t('label.date') }}: </span>{{ nowAsIsoDate() }}
+            <slot name="certifyDate">
+              <span class="font-bold">{{ $t('label.date') }}: </span>{{ nowAsIsoDate() }}
+            </slot>
           </div>
           <div>
-            <span class="font-bold">{{ $t('label.note') }}: </span>{{ $t('text.itIsAnOffenceToMakeFalseStatement') }}
+            <slot name="certifyNote">
+              <span class="font-bold">{{ $t('label.note') }}: </span>{{ $t('text.itIsAnOffenceToMakeFalseStatement') }}
+            </slot>
           </div>
         </div>
       </template>

--- a/web/post-restoration-transition-application/app/components/InfoBox.vue
+++ b/web/post-restoration-transition-application/app/components/InfoBox.vue
@@ -3,6 +3,8 @@ defineProps<{
   title: string
   text?: string
   icon?: string
+  titleClass?: string
+  textClass?: string
 }>()
 </script>
 
@@ -21,9 +23,9 @@ defineProps<{
     </slot>
     <ConnectInfoBox
       :title="title"
-      title-class="text-base"
+      :title-class="titleClass"
       :content="text"
-      content-class="text-base"
+      :content-class="textClass"
     />
   </div>
 </template>

--- a/web/post-restoration-transition-application/app/pages/[businessId].vue
+++ b/web/post-restoration-transition-application/app/pages/[businessId].vue
@@ -40,6 +40,7 @@ const {
   courtOrderNumber,
   directors,
   folio,
+  isStaffOrSbcStaff,
   legalName,
   offices,
   planOfArrangement,
@@ -138,6 +139,10 @@ const directorsColumns = ref([
     }
   }
 ])
+
+const displayLegalName = computed(() => {
+  return legalName.value || t('text.legalNameCertifyPlaceHolder')
+})
 </script>
 
 <template>
@@ -329,8 +334,20 @@ const directorsColumns = ref([
         <ConnectFormSection title=" ">
           <FormCertify
             v-model="certifiedByLegalName"
-            :legal-name="legalName"
-          />
+            :legal-name="displayLegalName || $t('text.legalNameCertifyPlaceHolder')"
+          >
+            <template v-if="isStaffOrSbcStaff" #certifyText>
+              <i18n-t
+                keypath="text.certifiesItHasRelevantKnowledgeStaff"
+                tag="p"
+                class="mt-[-2px]"
+              >
+                <template #legalName>
+                  <strong>{{ displayLegalName }}</strong>
+                </template>
+              </i18n-t>
+            </template>
+          </FormCertify>
         </ConnectFormSection>
       </FormSubSection>
     </FormSection>

--- a/web/post-restoration-transition-application/app/pages/[businessId].vue
+++ b/web/post-restoration-transition-application/app/pages/[businessId].vue
@@ -67,7 +67,10 @@ const officesColumns = ref([
   {
     accessorKey: 'mailingAddress',
     header: t('label.mailingAddress'),
-    cell: ({ row }) => { return h(ConnectAddressDisplay, { address: row.original.mailingAddress }) }
+    cell: ({ row }) => {
+      return h(ConnectAddressDisplay,
+        { address: row.original.mailingAddress })
+    }
   },
   {
     accessorKey: 'deliveryAddress',
@@ -130,7 +133,7 @@ const directorsColumns = ref([
       return h(
         'div',
         { class: 'text-left font-bold text-bgGovColor-midGray' },
-        'TODO: ADD CHANGE LINK HERE'
+        'TODO: ADD CHANGE LINK'
       )
     }
   }
@@ -139,14 +142,20 @@ const directorsColumns = ref([
 
 <template>
   <div class="py-10 space-y-10">
-    <div>
+    <section>
       <h1 class="mb-2">
         {{ $t('transitionApplication.title') }}
       </h1>
-      <p class="text-2xl">
-        {{ $t('text.transitionYourBusiness') }}
-      </p>
-    </div>
+      <i18n-t
+        keypath="text.transitionYourBusiness"
+        tag="p"
+        class="mb-4 text-[18px]"
+      >
+        <template #businessCorporationsAct>
+          <em>{{ $t('label.businessCorporationsAct') }}</em>
+        </template>
+      </i18n-t>
+    </section>
     <FormSection
       :title="$t('transitionApplication.subtitle.reviewAndConfirm')"
       :description="$t('text.reviewAndConfirmDescription')"
@@ -162,12 +171,17 @@ const directorsColumns = ref([
             :data="offices"
             :columns="officesColumns"
             class="m-6"
+            :ui="{
+              th: 'text-[14px] text-left text-bcGovColor-midGray p-4',
+              td: 'border-t-1 border-bcGovColor-hairlinesOnWhite text-[14px] whitespace-nowrap p-4 text-gray-500'
+            }"
           />
           <InfoBox
             icon="i-mdi-information-outline"
             :title="$t('text.needChange')"
             :text="$t('text.goToMainFileAddressChange')"
-            class="m-6"
+            class="pl-6 pr-6 text-[14px]"
+            title-class="text-[14px]"
           />
         </FormSubSection>
 
@@ -179,12 +193,17 @@ const directorsColumns = ref([
             :data="directors"
             :columns="directorsColumns"
             class="m-6"
+            :ui="{
+              th: 'text-[14px] text-left text-bcGovColor-midGray p-4',
+              td: 'border-t-1 border-bcGovColor-hairlinesOnWhite text-[14px] whitespace-nowrap p-4 text-gray-500'
+            }"
           />
           <InfoBox
             icon="i-mdi-information-outline"
             :title="$t('text.needOtherChange')"
             :text="$t('text.deleteAndFileDirectorChange')"
-            class="m-6"
+            class="pl-6 pr-6 text-[14px]"
+            title-class="text-[14px]"
           />
         </FormSubSection>
       </div>

--- a/web/post-restoration-transition-application/app/stores/post-restoration-transition-application.ts
+++ b/web/post-restoration-transition-application/app/stores/post-restoration-transition-application.ts
@@ -7,6 +7,7 @@ export const usePostRestorationTransitionApplicationStore
   const authApi = useAuthApi()
   const feeStore = useConnectFeeStore()
   const detailsHeaderStore = useConnectDetailsHeaderStore()
+  const { isStaffOrSbcStaff, userFullName } = storeToRefs(useConnectAccountStore())
   const activeBusiness = shallowRef<BusinessDataSlim>({} as BusinessDataSlim)
   const regOfficeEmail = ref<string | undefined>(undefined)
   const compPartyEmail = ref<string | undefined>(undefined)
@@ -104,6 +105,11 @@ export const usePostRestorationTransitionApplicationStore
       { label: t('label.phone'), value: phoneLabel }
     ]
 
+    // if user is client, autopopulate legalName
+    if (!isStaffOrSbcStaff.value) {
+      legalName.value = userFullName.value
+    }
+
     await _updateBreadcrumbs(businessId)
   }
 
@@ -114,6 +120,7 @@ export const usePostRestorationTransitionApplicationStore
     courtOrderNumber,
     directors,
     folio,
+    isStaffOrSbcStaff,
     legalName,
     offices,
     planOfArrangement,

--- a/web/post-restoration-transition-application/i18n/locales/en-CA.ts
+++ b/web/post-restoration-transition-application/i18n/locales/en-CA.ts
@@ -40,8 +40,9 @@ export default {
     to: 'to'
   },
   text: {
-    certifiesItHasRelevantKnowledge: 'certifies that they have relevant knowledge of the business and are authorized to make this filing.',
-    certifySectionDescription: 'Confirm the legal name of the person authorized to complete and submit this post-restoration transition application.',
+    certifiesItHasRelevantKnowledgeStaff: '{legalName} certifies that they have relevant knowledge of the business and are authorized to make this filing.',
+    certifiesItHasRelevantKnowledgeClient: 'I, {legalName} certify that I have relevant knowledge of the business and am authorized to make this filing.',
+    certifySectionDescription: 'Confirm the legal name of the person authorized to complete and submit this post restoration transition application.',
     companyProvisionsHeading: 'The Pre-existing Company Provisions apply to this company.',
     companyProvisionsText: 'The regulations under the {businessCorporationsAct} contain provisions that apply to a pre-existing company.',
     companyProvisionsURL: 'Read the Pre-existing Company Provisions',
@@ -57,7 +58,7 @@ export default {
     needChange: 'Need to make changes?',
     needOtherChange: 'Need to make other changes?',
     planOfArrangement: 'This filing is pursuant to a Plan of Arrangement',
-    reviewAndConfirmDescription: 'Office addresses, current directors and share structure must be correct before filing your transition application.',
+    reviewAndConfirmDescription: 'Office addresses, current directors and share structure must be correct before filing your application.',
     transitionYourBusiness: 'Transition your business so that it operates under the new {businessCorporationsAct}.'
   },
   ConnectFeeWidget: {

--- a/web/post-restoration-transition-application/i18n/locales/en-CA.ts
+++ b/web/post-restoration-transition-application/i18n/locales/en-CA.ts
@@ -47,7 +47,7 @@ export default {
     companyProvisionsURL: 'Read the Pre-existing Company Provisions',
     completingPartyEmail: 'The email of the person submitting this record.',
     courtOrder: 'If this filing is pursuant to a court order, enter the court order number. If this filing is pursuant to a plan of arrangement, enter the court order number and select the Plan of Arrangement checkbox.',
-    deleteAndFileDirectorChange: 'Delete this application and file a director change.',
+    deleteAndFileDirectorChange: 'Go the the main page of this business and file a director change.',
     documentDelivery: 'Copies of the transition documents will be sent to the email addresses listed below.',
     folioOrReferenceNumber: 'This is meant for your own tracking purposes and will appear on your receipt.',
     goToMainFileAddressChange: 'Go to main page of this business and file an address change.',
@@ -58,7 +58,7 @@ export default {
     needOtherChange: 'Need to make other changes?',
     planOfArrangement: 'This filing is pursuant to a Plan of Arrangement',
     reviewAndConfirmDescription: 'Office addresses, current directors and share structure must be correct before filing your transition application.',
-    transitionYourBusiness: 'Transition your business so that it operates under the new Business Corporations Act.'
+    transitionYourBusiness: 'Transition your business so that it operates under the new {businessCorporationsAct}.'
   },
   ConnectFeeWidget: {
     feeSummary: {


### PR DESCRIPTION
*Issue #:29290* /bcgov/entity###
*Issue #:28828* /bcgov/entity###
*Issue #:28826* /bcgov/entity###

*Description of changes:*
- updates to texts and styles
- autopopulating legalName in certify component, when client vs staff

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
