### PR TITLE
28874 - Implemented the type ahead dropdown component

### DIFF
--- a/web/business-registry-dashboard/app/components/MultiSelectTypeAhead.vue
+++ b/web/business-registry-dashboard/app/components/MultiSelectTypeAhead.vue
@@ -1,0 +1,172 @@
+<script setup lang="ts">
+const props = defineProps<{
+  modelValue: string[]
+  options: string[]
+  placeholder: string
+  disabled?: boolean
+  label: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string[]]
+}>()
+
+const { t } = useI18n()
+
+const query = ref('')
+const isOpen = ref(false)
+const inputRef = ref<any>()
+
+// Filter options based on prefix word matching
+const filteredOptions = computed(() => {
+  if (!query.value.trim()) {
+    return props.options
+  }
+
+  const searchTerms = query.value.toLowerCase().trim().split(/\s+/)
+
+  return props.options.filter((option) => {
+    const optionWords = option.toLowerCase().split(/\s+/)
+
+    // Every search term must match the start of some word in the option
+    return searchTerms.every(searchTerm =>
+      optionWords.some(word => word.startsWith(searchTerm))
+    )
+  })
+})
+
+// Display text for the trigger input
+const displayText = computed(() => {
+  // If dropdown is open and user is typing, don't show selection text
+  if (isOpen.value && query.value.trim()) {
+    return ''
+  }
+
+  if (props.modelValue.length === 0) {
+    return props.placeholder
+  } else if (props.modelValue.length === 1) {
+    return props.modelValue[0]
+  } else {
+    return t('words.Multiple')
+  }
+})
+
+// Handle option selection/deselection
+function toggleOption (option: string) {
+  const newValue = props.modelValue.includes(option)
+    ? props.modelValue.filter(item => item !== option)
+    : [...props.modelValue, option]
+
+  emit('update:modelValue', newValue)
+}
+
+// Handle input changes
+function handleInput (event: Event) {
+  if (isOpen.value) {
+    const target = event.target as HTMLInputElement
+    query.value = target.value
+  }
+}
+
+// Open dropdown
+function openDropdown () {
+  if (!props.disabled) {
+    isOpen.value = true
+    nextTick(() => {
+      if (inputRef.value && inputRef.value.$el) {
+        const input = inputRef.value.$el.querySelector('input')
+        if (input) {
+          input.focus()
+        }
+      }
+    })
+  }
+}
+
+// Close dropdown
+function closeDropdown () {
+  isOpen.value = false
+  query.value = ''
+}
+
+// Handle click outside to close dropdown
+const componentRef = ref<HTMLElement>()
+
+onClickOutside(componentRef, () => {
+  closeDropdown()
+})
+</script>
+
+<template>
+  <div ref="componentRef" class="relative">
+    <!-- Combined Trigger/Search Input -->
+    <div class="relative">
+      <!-- When closed: display area with text wrapping -->
+      <div
+        v-if="!isOpen"
+        class="flex h-[42px] w-full min-w-[200px] cursor-pointer items-center rounded-none rounded-t border-b border-gray-700 bg-gray-100 px-3 py-2 text-sm"
+        :class="{
+          'cursor-not-allowed opacity-75': disabled,
+          'hover:bg-gray-200': !disabled,
+          'text-gray-700': modelValue.length === 0,
+          'text-gray-900': modelValue.length > 0
+        }"
+        :aria-label="label"
+        @click="openDropdown"
+      >
+        <div class="w-full whitespace-normal break-words leading-tight">
+          {{ displayText }}
+        </div>
+      </div>
+
+      <!-- When open: search input -->
+      <UInput
+        v-else
+        ref="inputRef"
+        :model-value="query"
+        :placeholder="displayText"
+        :disabled="disabled"
+        variant="bcGovSm"
+        class="w-full min-w-[200px]"
+        :aria-label="label"
+        @input="handleInput"
+        @focus="() => {}"
+      />
+
+      <UIcon
+        name="i-mdi-caret-down"
+        class="pointer-events-none absolute right-3 top-1/2 size-5 -translate-y-1/2 text-gray-700 transition-transform duration-200"
+        :class="[isOpen && 'rotate-180']"
+      />
+    </div>
+
+    <!-- Dropdown -->
+    <div
+      v-if="isOpen"
+      class="absolute z-[999] mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-200 bg-white shadow-lg"
+    >
+      <!-- Options List -->
+      <div class="py-1">
+        <div
+          v-for="option in filteredOptions"
+          :key="option"
+          data-testid="option"
+          class="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-gray-50"
+          @click="toggleOption(option)"
+        >
+          <UCheckbox
+            :model-value="modelValue.includes(option)"
+            :aria-label="`Select ${option}`"
+            class="pointer-events-none"
+          />
+          <span class="flex-1 text-sm">{{ option }}</span>
+        </div>
+
+        <!-- No results message -->
+        <div v-if="filteredOptions.length === 0" class="px-3 py-2 text-sm text-gray-500">
+          {{ t('AsyncComboBox.noResults') }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
+++ b/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/Action.vue
@@ -505,7 +505,7 @@ const moreActionsDropdownOptions = computed<DropdownItem[][]>(() => {
       >
         <UButton
           :label="getPrimaryActionLabel(item)"
-          class="w-45 px-4 transition-all duration-200 hover:opacity-95 hover:brightness-125"
+          class="w-44 px-4 transition-all duration-200 hover:opacity-95 hover:brightness-125"
           :icon="affNav.isOpenExternal(item) ? 'i-mdi-open-in-new' : ''"
           :loading="isButtonActionProcessing"
           @click="primaryAction(item)"

--- a/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
+++ b/web/business-registry-dashboard/app/components/Table/AffiliatedEntity/index.vue
@@ -224,56 +224,19 @@ const mapDetailsWithEffectiveDate = (details: any[], row: any) => {
           }"
           @clear="affStore.affiliations.filters.type = []"
         >
-          <USelectMenu
+          <MultiSelectTypeAhead
             v-model="affStore.affiliations.filters.type"
             :options="affStore.typeOptions"
-            selected-icon="hidden"
-            multiple
+            :placeholder="$t('table.affiliation.filter.legalType.placeholder')"
             :disabled="affStore.affiliations.loading"
-            :ui="{ trigger: 'flex items-center w-full h-[42px] min-w-[210px]' }"
-          >
-            <template #default="{ open }">
-              <UButton
-                variant="select_menu_trigger"
-                class="w-full min-w-[210px] flex-1 justify-between text-gray-700"
-                :aria-label="$t('table.affiliation.filter.legalType.aria', {
-                  filter: affStore.affiliations.filters.type.length
-                    ? (affStore.affiliations.filters.type.length > 1
-                      ? $t('words.Multiple')
-                      : affStore.affiliations.filters.type[0])
-                    : $t('words.none')
-                })"
-              >
-                {{ affStore.affiliations.filters.type.length === 0
-                  ? $t('table.affiliation.filter.legalType.placeholder')
-                  : (affStore.affiliations.filters.type.length > 1
-                    ? $t('words.Multiple')
-                    : affStore.affiliations.filters.type[0]) }}
-                <UIcon name="i-mdi-caret-down" class="size-5 text-gray-700 transition-transform" :class="[open && 'rotate-180']" />
-              </UButton>
-            </template>
-
-            <template #option="{ option, selected }">
-              <div class="flex cursor-pointer items-center gap-2 pb-1">
-                <UCheckbox
-                  :model-value="selected"
-                  :aria-label="$t('btn.colsToShow.checkbox.aria', { column: option })"
-                  class="pointer-events-none"
-                />
-                <span>{{ option }}</span>
-              </div>
-              <!-- Add divider before specific options to separate groups -->
-              <template
-                v-if="affStore.enablePagination &&
-                  (option === FilterTypes.NAME_REQUEST || option === FilterTypes.INCORPORATION_APPLICATION)"
-              >
-                <div
-                  data-divider
-                  class="absolute right-0 w-full cursor-pointer border-t border-bcGovGray-300 py-5"
-                />
-              </template>
-            </template>
-          </USelectMenu>
+            :label="$t('table.affiliation.filter.legalType.aria', {
+              filter: affStore.affiliations.filters.type.length
+                ? (affStore.affiliations.filters.type.length > 1
+                  ? $t('words.Multiple')
+                  : affStore.affiliations.filters.type[0])
+                : $t('words.none')
+            })"
+          />
         </TableColumnHeader>
       </template>
 
@@ -289,58 +252,19 @@ const mapDetailsWithEffectiveDate = (details: any[], row: any) => {
           }"
           @clear="affStore.affiliations.filters.status = []"
         >
-          <USelectMenu
+          <MultiSelectTypeAhead
             v-model="affStore.affiliations.filters.status"
             :options="affStore.statusOptions"
-            selected-icon="hidden"
-            multiple
+            :placeholder="$t('table.affiliation.filter.busStates.placeholder')"
             :disabled="affStore.affiliations.loading"
-            :ui="{ trigger: 'flex items-center w-full h-[42px] min-w-[150px]' }"
-          >
-            <template #default="{ open }">
-              <UButton
-                variant="select_menu_trigger"
-                class="w-full min-w-[150px] flex-1 justify-between text-gray-700"
-                :aria-label="$t('table.affiliation.filter.busStates.aria', {
-                  filter: affStore.affiliations.filters.status.length
-                    ? (affStore.affiliations.filters.status.length > 1
-                      ? $t('words.Multiple')
-                      : affStore.affiliations.filters.status[0])
-                    : $t('words.none')
-                })"
-              >
-                {{ affStore.affiliations.filters.status.length === 0
-                  ? $t('table.affiliation.filter.busStates.placeholder')
-                  : (affStore.affiliations.filters.status.length > 1
-                    ? $t('words.Multiple')
-                    : affStore.affiliations.filters.status[0]) }}
-                <UIcon name="i-mdi-caret-down" class="size-5 text-gray-700 transition-transform" :class="[open && 'rotate-180']" />
-              </UButton>
-            </template>
-
-            <template #option="{ option, selected }">
-              <div class="flex cursor-pointer items-center gap-2 pb-1">
-                <UCheckbox
-                  :model-value="selected"
-                  :aria-label="$t('btn.colsToShow.checkbox.aria', { column: option })"
-                  class="pointer-events-none"
-                />
-                <span>{{ option }}</span>
-              </div>
-              <!-- Add divider before specific options to separate groups -->
-              <template
-                v-if="affStore.enablePagination &&
-                  (option === NrDisplayStates.APPROVED ||
-                    option === EntityStateStatus.WITHDRAWN ||
-                    option === EntityStateStatus.PAID)"
-              >
-                <div
-                  data-divider
-                  class="absolute right-0 w-full cursor-pointer border-t border-bcGovGray-300 py-5"
-                />
-              </template>
-            </template>
-          </USelectMenu>
+            :label="$t('table.affiliation.filter.busStates.aria', {
+              filter: affStore.affiliations.filters.status.length
+                ? (affStore.affiliations.filters.status.length > 1
+                  ? $t('words.Multiple')
+                  : affStore.affiliations.filters.status[0])
+                : $t('words.none')
+            })"
+          />
         </TableColumnHeader>
       </template>
 

--- a/web/business-registry-dashboard/package.json
+++ b/web/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/web/business-registry-dashboard/tests/unit/components/MultiSelectTypeAhead.test.ts
+++ b/web/business-registry-dashboard/tests/unit/components/MultiSelectTypeAhead.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { nextTick } from 'vue'
+import { MultiSelectTypeAhead } from '#components'
+import { enI18n } from '~~/tests/mocks/i18n'
+
+const mockOptions = [
+  'BC Sole Proprietorship',
+  'BC Limited Company',
+  'BC Unlimited Liability Company',
+  'BC General Partnership',
+  'BC Benefit Company',
+  'BC Community Contribution Company',
+  'BC Cooperative Association',
+  'Extraprovincial Company',
+  'Name Request',
+  'Registration',
+  'Incorporation Application',
+  'Continuation Application',
+  'Amalgamation Application'
+]
+
+describe('MultiSelectTypeAhead', () => {
+  const defaultProps = {
+    modelValue: [],
+    options: mockOptions,
+    placeholder: 'Select type...',
+    label: 'Filter by type'
+  }
+
+  it('should mount successfully', async () => {
+    const wrapper = await mountSuspended(MultiSelectTypeAhead, {
+      props: defaultProps,
+      global: {
+        plugins: [enI18n]
+      }
+    })
+
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('should filter options based on prefix word matching', async () => {
+    const wrapper = await mountSuspended(MultiSelectTypeAhead, {
+      props: defaultProps,
+      global: {
+        plugins: [enI18n]
+      }
+    })
+
+    // Click on the display div to open the dropdown first
+    await wrapper.find('div[class*="cursor-pointer"]').trigger('click')
+    await nextTick()
+
+    // Now find the input that appears when opened
+    const input = wrapper.find('input')
+    await input.setValue('BC')
+    await input.trigger('input')
+    await nextTick()
+
+    // Should match all options that start with "BC"
+    const visibleOptions = wrapper.findAll('[data-testid="option"]')
+    expect(visibleOptions.length).toBeGreaterThan(0)
+
+    // Verify that "Name Request" is NOT included (doesn't start with "BC")
+    const optionTexts = visibleOptions.map(option => option.text())
+    expect(optionTexts).not.toContain('Name Request')
+    expect(optionTexts).toContain('BC Limited Company')
+  })
+
+  it('should match words that start with search term (not middle of words)', async () => {
+    const wrapper = await mountSuspended(MultiSelectTypeAhead, {
+      props: defaultProps,
+      global: {
+        plugins: [enI18n]
+      }
+    })
+
+    // Click on the display div to open the dropdown first
+    await wrapper.find('div[class*="cursor-pointer"]').trigger('click')
+    await nextTick()
+
+    const input = wrapper.find('input')
+
+    // Test "Re" - should match "Registration" (starts with "Re")
+    // but NOT "Extraprovincial" (has "re" in middle)
+    await input.setValue('Re')
+    await input.trigger('input')
+    await nextTick()
+
+    const visibleOptions = wrapper.findAll('[data-testid="option"]')
+    const optionTexts = visibleOptions.map(option => option.text())
+
+    expect(optionTexts).toContain('Registration')
+    expect(optionTexts).not.toContain('Extraprovincial Company')
+  })
+
+  it('should handle multi-word matching correctly', async () => {
+    const wrapper = await mountSuspended(MultiSelectTypeAhead, {
+      props: defaultProps,
+      global: {
+        plugins: [enI18n]
+      }
+    })
+
+    // Click on the display div to open the dropdown first
+    await wrapper.find('div[class*="cursor-pointer"]').trigger('click')
+    await nextTick()
+
+    const input = wrapper.find('input')
+
+    // Test "App" - should match "Incorporation Application" and "Amalgamation Application"
+    await input.setValue('App')
+    await input.trigger('input')
+    await nextTick()
+
+    const visibleOptions = wrapper.findAll('[data-testid="option"]')
+    const optionTexts = visibleOptions.map(option => option.text())
+
+    expect(optionTexts).toContain('Incorporation Application')
+    expect(optionTexts).toContain('Amalgamation Application')
+    expect(optionTexts).toContain('Continuation Application')
+  })
+
+  it('should show all options when search is empty', async () => {
+    const wrapper = await mountSuspended(MultiSelectTypeAhead, {
+      props: defaultProps,
+      global: {
+        plugins: [enI18n]
+      }
+    })
+
+    // Click on the display div to open the dropdown first
+    await wrapper.find('div[class*="cursor-pointer"]').trigger('click')
+    await nextTick()
+
+    const visibleOptions = wrapper.findAll('[data-testid="option"]')
+    expect(visibleOptions.length).toBe(mockOptions.length)
+  })
+
+  it('should display correct text based on selection', async () => {
+    const wrapper = await mountSuspended(MultiSelectTypeAhead, {
+      props: {
+        ...defaultProps,
+        modelValue: ['BC Limited Company']
+      },
+      global: {
+        plugins: [enI18n]
+      }
+    })
+
+    // When closed, check the display div content
+    const displayDiv = wrapper.find('div[class*="cursor-pointer"]')
+    expect(displayDiv.text()).toContain('BC Limited Company')
+
+    // Test multiple selections
+    await wrapper.setProps({
+      modelValue: ['BC Limited Company', 'Registration']
+    })
+    await nextTick()
+
+    expect(displayDiv.text()).toContain('Multiple')
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28874

*Description of changes:*
This was tough and fun to implement.

From Jacqueline:
- add type ahead feature to TYPE and STATUS filters on BRD
- users should be able to type into the filter field and the list should filter based on their entry
  - The filter should match only words that **start** with the typed input
  - For example if I type "Re", I should see list items that have words that start with "Re", like "Pending Review". But I wouldn't see items like "Expired", where "re" is in the middle of the word.

Example:
<img width="308" height="258" alt="image" src="https://github.com/user-attachments/assets/6bcf4c68-4761-46f5-bca0-0a0ad1037d7a" />

Please reviewers, if you can take 5 minutes and test different scenarios to check if there are any bugs, I would really appreciate it. Thanks!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
