### PR TITLE
30534 - update breadcrumbs

### DIFF
--- a/web/person-roles/app/composables/useOfficerNavigation.ts
+++ b/web/person-roles/app/composables/useOfficerNavigation.ts
@@ -19,29 +19,43 @@ export const useOfficerNavigation = () => {
 
   const dashboardOrEditUrl = computed(() => isDraft.value ? dashboardUrl.value : editUrl.value)
 
-  const breadcrumbs = computed(() => [
-    {
-      label: t('label.bcRegistriesDashboard'),
-      to: `${rtc.registryHomeUrl}dashboard`,
-      external: true,
-      appendAccountId: true
-    },
-    {
-      label: t('label.myBusinessRegistry'),
-      to: `${rtc.brdUrl}account/${accountStore.currentAccount.id}`,
-      external: true
-    },
-    {
-      label: isDraft.value
-        ? officerStore.activeBusiness.legalName
-        : t('label.companyInformationPage'),
-      to: dashboardOrEditUrl.value,
-      external: true
-    },
-    {
-      label: t('page.officerChange.h1')
+  const breadcrumbs = computed<ConnectBreadcrumb[]>(() => {
+    // always show reg home, brd and business dashboard crumbs
+    const crumbs: ConnectBreadcrumb[] = [
+      {
+        label: t('label.bcRegistriesDashboard'),
+        to: `${rtc.registryHomeUrl}dashboard`,
+        external: true,
+        appendAccountId: true
+      },
+      {
+        label: t('label.myBusinessRegistry'),
+        to: `${rtc.brdUrl}account/${accountStore.currentAccount.id}`,
+        external: true
+      },
+      {
+        label: officerStore.activeBusiness.legalName,
+        to: dashboardUrl.value,
+        external: true
+      }
+    ]
+
+    // only add company info crumb if not draft
+    if (!isDraft.value) {
+      crumbs.push({
+        label: t('label.companyInformationPage'),
+        to: editUrl.value,
+        external: true
+      })
     }
-  ])
+
+    // always have officer change final breadcrumb
+    crumbs.push({
+      label: t('page.officerChange.h1')
+    })
+
+    return crumbs
+  })
 
   return {
     isDraft,

--- a/web/person-roles/package.json
+++ b/web/person-roles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "person-roles",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.13.1",

--- a/web/person-roles/tests/unit/composables/useOfficerNavigation.spec.ts
+++ b/web/person-roles/tests/unit/composables/useOfficerNavigation.spec.ts
@@ -49,13 +49,15 @@ describe('useOfficerNavigation', () => {
     })
 
     it('should return the correct breadcrumbs for a non-draft filing', () => {
-      const { breadcrumbs, editUrl } = useOfficerNavigation()
+      const { breadcrumbs, editUrl, dashboardUrl } = useOfficerNavigation()
       const breadcrumbItems = breadcrumbs.value
 
-      expect(breadcrumbItems).toHaveLength(4)
+      expect(breadcrumbItems).toHaveLength(5)
 
-      expect(breadcrumbItems[2]!.label).toBe('Company Information Page')
-      expect(breadcrumbItems[2]!.to).toBe(editUrl.value)
+      expect(breadcrumbItems[2]!.label).toBe('Test Business Inc.')
+      expect(breadcrumbItems[2]!.to).toBe(dashboardUrl.value)
+      expect(breadcrumbItems[3]!.label).toBe('Company Information Page')
+      expect(breadcrumbItems[3]!.to).toBe(editUrl.value)
     })
   })
 
@@ -87,10 +89,14 @@ describe('useOfficerNavigation', () => {
 
   describe('Computeds', () => {
     it('should update URLs and breadcrumbs when the route query changes', async () => {
-      const { isDraft, dashboardOrEditUrl, breadcrumbs, editUrl } = useOfficerNavigation()
+      const { isDraft, dashboardOrEditUrl, dashboardUrl, breadcrumbs, editUrl } = useOfficerNavigation()
       expect(isDraft.value).toBe(false)
       expect(dashboardOrEditUrl.value).toBe(editUrl.value)
-      expect(breadcrumbs.value[2]!.label).toBe('Company Information Page')
+      expect(breadcrumbs.value[2]!.label).toBe('Test Business Inc.')
+      expect(breadcrumbs.value[2]!.to).toBe(dashboardUrl.value)
+      expect(breadcrumbs.value[3]!.label).toBe('Company Information Page')
+      expect(breadcrumbs.value[3]!.to).toBe(editUrl.value)
+      expect(breadcrumbs.value).toHaveLength(5)
 
       mockRoute.query = { draft: 'filing-123' }
       await nextTick()
@@ -98,6 +104,7 @@ describe('useOfficerNavigation', () => {
       expect(isDraft.value).toBe(true)
       expect(dashboardOrEditUrl.value).not.toBe(editUrl.value)
       expect(breadcrumbs.value[2]!.label).toBe('Test Business Inc.')
+      expect(breadcrumbs.value).toHaveLength(4)
     })
   })
 })


### PR DESCRIPTION
*Issue #:* bcgov/entity#30534

*Description of changes:*
- breadcrumbs always have dashboard url 
- only add company info page if not draft

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
