### PR TITLE
Add specific alert text to manage business modal for SAF flow

### DIFF
--- a/web/business-registry-dashboard/app/components/Modal/ManageBusiness.vue
+++ b/web/business-registry-dashboard/app/components/Modal/ManageBusiness.vue
@@ -11,6 +11,7 @@ const ldStore = useConnectLaunchdarklyStore()
 const props = defineProps<{
   alert?: ModalAlertProps
   business: ManageBusinessEvent
+  isSaf?: boolean // Flag for SAF (simplified account flow) specific UI differences - currently only changes the email auth option text
 }>()
 
 const emailSent = ref(false)
@@ -77,13 +78,15 @@ const authOptions = computed<AccordionItem[]>(() => {
 
   if (showEmailOption.value) {
     options.push({
-      label: businessDetails.value.isCoop
-        ? t('form.manageBusiness.authOption.email.radioLabel.coop')
-        : isCorpOrBenOrCoop.value
-          ? t('form.manageBusiness.authOption.email.radioLabel.corpOrBenOrCoop')
-          : businessDetails.value.isFirm && contactEmail.value !== ''
-            ? t('form.manageBusiness.authOption.email.radioLabel.firm')
-            : t('form.manageBusiness.authOption.email.radioLabel.default'),
+      label: props.isSaf
+        ? t('form.manageBusiness.authOption.email.radioLabel.safAffiliation')
+        : businessDetails.value.isCoop
+          ? t('form.manageBusiness.authOption.email.radioLabel.coop')
+          : isCorpOrBenOrCoop.value
+            ? t('form.manageBusiness.authOption.email.radioLabel.corpOrBenOrCoop')
+            : businessDetails.value.isFirm && contactEmail.value !== ''
+              ? t('form.manageBusiness.authOption.email.radioLabel.firm')
+              : t('form.manageBusiness.authOption.email.radioLabel.default'),
       slot: 'email-option'
     })
   }

--- a/web/business-registry-dashboard/app/composables/useBrdModals.ts
+++ b/web/business-registry-dashboard/app/composables/useBrdModals.ts
@@ -194,8 +194,8 @@ export const useBrdModals = () => {
     }
   }
 
-  function openManageBusiness (business: ManageBusinessEvent, alert?: ModalAlertProps) {
-    modal.open(ModalManageBusiness, { business, alert })
+  function openManageBusiness (business: ManageBusinessEvent, alert?: ModalAlertProps, isSaf?: boolean) {
+    modal.open(ModalManageBusiness, { business, alert, isSaf })
   }
 
   function openAuthEmailSent (email: string) {

--- a/web/business-registry-dashboard/app/pages/affiliationInvitation/acceptToken.vue
+++ b/web/business-registry-dashboard/app/pages/affiliationInvitation/acceptToken.vue
@@ -109,17 +109,21 @@ const parseUrlAndAddAffiliation = async (token: any, base64Token: string) => {
         }
         const safErrorType = safErrorMap[errorCode] || 'generic'
 
-        brdModal.openManageBusiness({
-          identifier,
-          legalType: businessInfo.business.legalType,
-          name: businessInfo.business.legalName,
-          status: businessInfo.business.state
-        }, {
-          color: 'red',
-          translationPath: `form.manageBusiness.safAffiliationAlert.${safErrorType}`,
-          icon: 'i-mdi-warning',
-          variant: 'subtle'
-        })
+        brdModal.openManageBusiness(
+          {
+            identifier,
+            legalType: businessInfo.business.legalType,
+            name: businessInfo.business.legalName,
+            status: businessInfo.business.state
+          },
+          {
+            color: 'red',
+            translationPath: `form.manageBusiness.safAffiliationAlert.${safErrorType}`,
+            icon: 'i-mdi-warning',
+            variant: 'subtle'
+          },
+          true
+        )
       } catch (businessError: any) {
         console.error(businessError)
         brdModal.openBusinessAddError()

--- a/web/business-registry-dashboard/app/pages/affiliationInvitation/acceptToken.vue
+++ b/web/business-registry-dashboard/app/pages/affiliationInvitation/acceptToken.vue
@@ -2,7 +2,7 @@
 import { inflate } from 'pako'
 import { StatusCodes } from 'http-status-codes'
 
-const { $businessApi } = useNuxtApp()
+const { $businessApi, $authApi } = useNuxtApp()
 const { t } = useNuxtApp().$i18n
 const affStore = useAffiliationsStore()
 const brdModal = useBrdModals()
@@ -70,15 +70,30 @@ const parseUrlAndAddAffiliation = async (token: any, base64Token: string) => {
     }
   } catch (error: any) {
     console.error(error)
-    // Generic email affiliation error when there is no fromOrgId (special migration flow affiliation)
-    if (
-      !fromOrgId &&
-      !(
-        error.response?.status === StatusCodes.BAD_REQUEST &&
-        error.response?._data?.rootCause?.code === MagicLinkInvitationStatus.ACTIONED_AFFILIATION_INVITATION
-      )
-    ) {
+    const errorCode = error.response?._data?.code || error.response?._data?.rootCause?.code
+    const errorStatus = error.response?.status
+    const isBadRequest = errorStatus === StatusCodes.BAD_REQUEST
+    const isExpired = errorCode === MagicLinkInvitationStatus.EXPIRED_AFFILIATION_INVITATION
+    const isActioned = errorCode === MagicLinkInvitationStatus.ACTIONED_AFFILIATION_INVITATION
+
+    // Email affiliation error when there is no fromOrgId (special migration flow affiliation)
+    if (!fromOrgId && isBadRequest) {
       try {
+        // In SAF + Affiliation flow, this link could have been used by another user or account
+        // causing the invitation to be `ACCEPTED`, need to confirm business has been added to this account specifically
+        if (isActioned) {
+          const accountId = useConnectAccountStore().currentAccount.id
+          const { entities } = await $authApi<{ entities: AffiliationResponse[] }>(`/orgs/${accountId}/affiliations?new=true`)
+          const alreadyAdded = entities.find(b => b.identifier === identifier)
+
+          if (alreadyAdded) {
+            brdModal.openMagicLinkModal(t('error.magicLinkAlreadyAdded.title'), t('error.magicLinkAlreadyAdded.description', { identifier }))
+            return
+          }
+        }
+
+        // If link is expired, actioned by a different account or any other error, open manage business modal
+        // prompting the user to send a new affiliation request
         // FUTURE: replace with business layer business store init (handles all mapping, typing, etc.)
         const businessInfo: {
           business: {
@@ -88,6 +103,12 @@ const parseUrlAndAddAffiliation = async (token: any, base64Token: string) => {
           }
         } = await $businessApi(`/businesses/${identifier}/public?slim=true`)
 
+        const safErrorMap: Record<string, string> = {
+          [MagicLinkInvitationStatus.EXPIRED_AFFILIATION_INVITATION]: 'expired',
+          [MagicLinkInvitationStatus.ACTIONED_AFFILIATION_INVITATION]: 'actioned'
+        }
+        const safErrorType = safErrorMap[errorCode] || 'generic'
+
         brdModal.openManageBusiness({
           identifier,
           legalType: businessInfo.business.legalType,
@@ -95,7 +116,7 @@ const parseUrlAndAddAffiliation = async (token: any, base64Token: string) => {
           status: businessInfo.business.state
         }, {
           color: 'red',
-          translationPath: 'form.manageBusiness.expiredLink',
+          translationPath: `form.manageBusiness.safAffiliationAlert.${safErrorType}`,
           icon: 'i-mdi-warning',
           variant: 'subtle'
         })
@@ -106,19 +127,17 @@ const parseUrlAndAddAffiliation = async (token: any, base64Token: string) => {
       return
     }
     // Unauthorized
-    if (error.response?.status === StatusCodes.UNAUTHORIZED) {
+    if (errorStatus === StatusCodes.UNAUTHORIZED) {
       brdModal.openMagicLinkModal(t('error.magicLinkUnauthorized.title'), t('error.magicLinkUnauthorized.description'))
       return
     }
     // Expired
-    if (error.response?.status === StatusCodes.BAD_REQUEST &&
-      error.response?._data?.rootCause?.code === MagicLinkInvitationStatus.EXPIRED_AFFILIATION_INVITATION) {
+    if (isBadRequest && isExpired) {
       brdModal.openMagicLinkModal(t('error.magicLinkExpired.title'), t('error.magicLinkExpired.description', { identifier }))
       return
     }
     // Already Added
-    if (error.response?.status === StatusCodes.BAD_REQUEST &&
-      error.response?._data?.rootCause?.code === MagicLinkInvitationStatus.ACTIONED_AFFILIATION_INVITATION) {
+    if (isBadRequest && isActioned) {
       brdModal.openMagicLinkModal(t('error.magicLinkAlreadyAdded.title'), t('error.magicLinkAlreadyAdded.description', { identifier }))
       return
     }

--- a/web/business-registry-dashboard/i18n/locales/en-CA.ts
+++ b/web/business-registry-dashboard/i18n/locales/en-CA.ts
@@ -486,7 +486,12 @@ export default {
         }
       },
       submitBtn: 'Manage this Business',
-      noOptionAlert: 'Please select an option from the list above'
+      noOptionAlert: 'Please select an option from the list above',
+      safAffiliationAlert: { // only used when the simplified account flow + affiliation fails
+        expired: '{boldStart}Important:{boldEnd} The business could not be added to your account due to an expired link. Please send a new request below.',
+        actioned: '{boldStart}Important:{boldEnd} This link is no longer active as it has already been processed. Please send a new request below.',
+        generic: '{boldStart}Important:{boldEnd} The business could not be added to your account due to an internal error. Please send a new request below.'
+      }
     }
   },
   labels: {

--- a/web/business-registry-dashboard/i18n/locales/en-CA.ts
+++ b/web/business-registry-dashboard/i18n/locales/en-CA.ts
@@ -489,9 +489,9 @@ export default {
       submitBtn: 'Manage this Business',
       noOptionAlert: 'Please select an option from the list above',
       safAffiliationAlert: { // only used when the simplified account flow + affiliation fails
-        expired: '{boldStart}Important:{boldEnd} The business could not be added to your account due to an expired link. Please send a new request below.',
-        actioned: '{boldStart}Important:{boldEnd} This link is no longer active as it has already been processed. Please send a new request below.',
-        generic: '{boldStart}Important:{boldEnd} The business could not be added to your account due to an internal error. Please send a new request below.'
+        expired: '{boldStart}Important:{boldEnd} The business could not be added to your account due to an expired link. Please select an option below to send a new request.',
+        actioned: '{boldStart}Important:{boldEnd} This link is no longer active as it has already been processed. Please select an option below to send a new request.',
+        generic: '{boldStart}Important:{boldEnd} The business could not be added to your account due to an internal error. Please select an option below to send a new request.'
       }
     }
   },

--- a/web/business-registry-dashboard/i18n/locales/en-CA.ts
+++ b/web/business-registry-dashboard/i18n/locales/en-CA.ts
@@ -389,7 +389,8 @@ export default {
             default: 'Confirm authorization using your email address',
             firm: 'Confirm authorization using your business email address',
             corpOrBenOrCoop: 'Confirm authorization using your registered office email address',
-            coop: 'Confirm authorization using your registered office email address'
+            coop: 'Confirm authorization using your registered office email address',
+            safAffiliation: 'Use your registered office email address to send a new link'
           },
           coopSubtext: '(If you forgot or don\'t have a business passcode)',
           sentTo: {

--- a/web/business-registry-dashboard/package.json
+++ b/web/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "engines": {
     "node": ">=24"
   },

--- a/web/business-registry-dashboard/tests/unit/pages/acceptToken.test.ts
+++ b/web/business-registry-dashboard/tests/unit/pages/acceptToken.test.ts
@@ -173,7 +173,8 @@ describe('AcceptToken Page', () => {
 
       expect(mockBrdModal.openManageBusiness).toHaveBeenCalledWith(
         expect.objectContaining({ identifier }),
-        expect.objectContaining({ translationPath: 'form.manageBusiness.safAffiliationAlert.expired' })
+        expect.objectContaining({ translationPath: 'form.manageBusiness.safAffiliationAlert.expired' }),
+        true
       )
     })
 
@@ -228,7 +229,8 @@ describe('AcceptToken Page', () => {
 
       expect(mockBrdModal.openManageBusiness).toHaveBeenCalledWith(
         expect.any(Object),
-        expect.objectContaining({ translationPath: 'form.manageBusiness.safAffiliationAlert.actioned' })
+        expect.objectContaining({ translationPath: 'form.manageBusiness.safAffiliationAlert.actioned' }),
+        true
       )
     })
 
@@ -253,7 +255,8 @@ describe('AcceptToken Page', () => {
         expect.any(Object),
         expect.objectContaining({
           translationPath: 'form.manageBusiness.safAffiliationAlert.generic'
-        })
+        }),
+        true
       )
     })
   })

--- a/web/business-registry-dashboard/tests/unit/pages/acceptToken.test.ts
+++ b/web/business-registry-dashboard/tests/unit/pages/acceptToken.test.ts
@@ -19,6 +19,36 @@ mockNuxtImport('useRoute', () => {
   })
 })
 
+mockNuxtImport('useConnectAccountStore', () => () => ({
+  currentAccount: { id: 1234 }
+}))
+
+const mockAuthApi = vi.fn()
+const mockBusinessApi = vi.fn()
+mockNuxtImport('useNuxtApp', () => {
+  return () => ({
+    $authApi: mockAuthApi,
+    $businessApi: mockBusinessApi,
+    $i18n: {
+      t: (key: string) => key
+    },
+    payload: {
+      state: {}
+    }
+  })
+})
+
+mockNuxtImport('useModal', () => () => ({ open: vi.fn() }))
+
+const { mockAcceptInvitation } = vi.hoisted(() => ({ mockAcceptInvitation: vi.fn() }))
+vi.mock('~/services/affiliation-invitation-service', () => {
+  return {
+    default: {
+      acceptInvitation: mockAcceptInvitation
+    }
+  }
+})
+
 // Mock toast notifications service
 const mockToast = {
   add: vi.fn()
@@ -27,8 +57,11 @@ const mockToast = {
 // Mock modal service for displaying various modals
 const mockBrdModal = {
   openMagicLinkModal: vi.fn(),
-  openBusinessAddError: vi.fn()
+  openBusinessAddError: vi.fn(),
+  openManageBusiness: vi.fn()
 }
+
+mockNuxtImport('useBrdModals', () => () => mockBrdModal)
 
 // Sample parsed token data structure for testing
 const mockParsedToken = {
@@ -97,5 +130,131 @@ describe('AcceptToken Page', () => {
     const uncompressedToken = component.parseToken(UNCOMPRESSED_TOKEN)
     expect(uncompressedToken.businessIdentifier).toBeDefined()
     expect(uncompressedToken.id).toBeDefined()
+  })
+
+  describe('SAF Affiliation Error Handling', () => {
+    const identifier = 'BC1234567'
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      mockBusinessApi.mockResolvedValue({
+        business: { legalType: 'BC', legalName: 'Testing Inc', state: 'ACTIVE' }
+      })
+
+      mockAuthApi.mockResolvedValue({ entities: [] })
+    })
+
+    const initMocks = (component: any, invitationError: object) => {
+      vi.spyOn(component, 'parseToken').mockReturnValue({
+        fromOrgId: null,
+        businessIdentifier: identifier,
+        id: '87654'
+      })
+
+      mockAcceptInvitation.mockRejectedValue(invitationError)
+    }
+
+    it('opens Manage Business modal with "expired" alert when link is expired', async () => {
+      const wrapper = mountComponent()
+      const component = wrapper.vm as any
+
+      const expiredError = {
+        response: {
+          status: 400,
+          _data: { code: 'EXPIRED_AFFILIATION_INVITATION' }
+        }
+      }
+
+      initMocks(component, expiredError)
+
+      await component.parseUrlAndAddAffiliation({ businessIdentifier: identifier, id: '1', fromOrgId: null }, 'token')
+
+      expect(mockAcceptInvitation).toHaveBeenCalled()
+
+      expect(mockBrdModal.openManageBusiness).toHaveBeenCalledWith(
+        expect.objectContaining({ identifier }),
+        expect.objectContaining({ translationPath: 'form.manageBusiness.safAffiliationAlert.expired' })
+      )
+    })
+
+    it('checks affiliations and shows "already added" modal if business is in account', async () => {
+      const wrapper = mountComponent()
+      const component = wrapper.vm as any
+
+      const actionedError = {
+        response: {
+          status: 400,
+          _data: { code: 'ACTIONED_AFFILIATION_INVITATION' }
+        }
+      }
+
+      initMocks(component, actionedError)
+
+      // mock already added to account
+      mockAuthApi.mockResolvedValue({
+        entities: [{ identifier, name: 'Testing Inc' }]
+      })
+
+      await component.parseUrlAndAddAffiliation({ businessIdentifier: identifier, id: '1', fromOrgId: null }, 'token')
+
+      expect(mockAcceptInvitation).toHaveBeenCalled()
+
+      expect(mockBrdModal.openMagicLinkModal).toHaveBeenCalledWith(
+        'error.magicLinkAlreadyAdded.title',
+        'error.magicLinkAlreadyAdded.description'
+      )
+      expect(mockBrdModal.openManageBusiness).not.toHaveBeenCalled()
+    })
+
+    it('opens Manage Business modal with "actioned" alert if business is NOT in account', async () => {
+      const wrapper = mountComponent()
+      const component = wrapper.vm as any
+
+      const actionedError = {
+        response: {
+          status: 400,
+          _data: { code: 'ACTIONED_AFFILIATION_INVITATION' }
+        }
+      }
+
+      initMocks(component, actionedError)
+
+      // invitation ACCEPTED but not in orgs affiliations
+      mockAuthApi.mockResolvedValue({ entities: [] })
+
+      await component.parseUrlAndAddAffiliation({ businessIdentifier: identifier, id: '1', fromOrgId: null }, 'token')
+
+      expect(mockAcceptInvitation).toHaveBeenCalled()
+
+      expect(mockBrdModal.openManageBusiness).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ translationPath: 'form.manageBusiness.safAffiliationAlert.actioned' })
+      )
+    })
+
+    it('opens Manage Business modal with "generic" alert for unknown SAF errors', async () => {
+      const wrapper = mountComponent()
+      const component = wrapper.vm as any
+
+      const unknownError = {
+        response: {
+          status: 400,
+          _data: { code: 'UNKNOWN_ERROR_CODE' }
+        }
+      }
+
+      initMocks(component, unknownError)
+
+      await component.parseUrlAndAddAffiliation({ businessIdentifier: identifier, id: '1', fromOrgId: null }, 'token')
+
+      expect(mockAcceptInvitation).toHaveBeenCalled()
+
+      expect(mockBrdModal.openManageBusiness).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          translationPath: 'form.manageBusiness.safAffiliationAlert.generic'
+        })
+      )
+    })
   })
 })


### PR DESCRIPTION
*Issue #:* 
- bcgov/entity#33146
- bcgov/entity#32637

**NOTE: Please touch base with me if you (reviewers) would like to test this with the temp URL**

**Alert suffix text in screenshots: 'Please send a new request below' changed to 'Please select an option below to send a new request.'**

*Description of changes:*
Expired Text:

<img width="1550" height="1034" alt="image" src="https://github.com/user-attachments/assets/01f88c37-d8ea-49fc-914d-e3e18eb9512a" />

Link already used by a different account:

<img width="1628" height="1096" alt="image" src="https://github.com/user-attachments/assets/d4f6eec3-9c83-4a6d-8d7b-2b834a0ceec4" />

Link already used by this same account:

<img width="1278" height="686" alt="image" src="https://github.com/user-attachments/assets/8c366336-69cd-45ba-85a2-1acb0e99e6ae" />


Any other error:

<img width="1550" height="1030" alt="image" src="https://github.com/user-attachments/assets/005d9422-dfac-4d7f-ac79-b817da16c8d9" />


Email option specific to SAF only:

<img width="731" height="107" alt="Screenshot 2026-04-15 at 9 26 01 AM" src="https://github.com/user-attachments/assets/3bdfd758-bacc-4dcb-b004-70d84b69e7b1" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
