### PR TITLE
33207 - switch account in acceptToken flow if possible

### DIFF
--- a/web/business-registry-dashboard/app/pages/affiliationInvitation/acceptToken.vue
+++ b/web/business-registry-dashboard/app/pages/affiliationInvitation/acceptToken.vue
@@ -5,6 +5,7 @@ import { StatusCodes } from 'http-status-codes'
 const { $businessApi, $authApi } = useNuxtApp()
 const { t } = useNuxtApp().$i18n
 const affStore = useAffiliationsStore()
+const accountStore = useConnectAccountStore()
 const brdModal = useBrdModals()
 const route = useRoute()
 
@@ -42,6 +43,11 @@ definePageMeta({
 onMounted(async () => {
   try {
     const token = parseToken(route.query.token as string)
+    // required when the user has more than 1 account
+    // NB: `unaffiliated` token from migration will not have fromOrgId
+    if (token.fromOrgId) {
+      accountStore.switchCurrentAccount(token.fromOrgId)
+    }
     // Parse the URL and try to add the affiliation
     parseUrlAndAddAffiliation(token, route.query.token as string)
     // Load affiliations to update the table

--- a/web/business-registry-dashboard/package.json
+++ b/web/business-registry-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "business-registry-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "engines": {
     "node": ">=24"
   },

--- a/web/business-registry-dashboard/tests/unit/pages/acceptToken.test.ts
+++ b/web/business-registry-dashboard/tests/unit/pages/acceptToken.test.ts
@@ -8,10 +8,14 @@ const COMPRESSED_TOKEN = '.eJyrVspMUbKyMDHTUUorys_1L0r3BPLzSnNydJRK8lG4SaXFmXmpx
 const UNCOMPRESSED_TOKEN = 'eyJpZCI6OCwiZnJvbU9yZ0lkIjoyNTIzLCJ0b09yZ0lkIjoyOTk0LCJidXNpbmVzc0lkZW50aWZpZXIiOiJCQzA4NzEzMzAifQ.ZNPNWg.lrG2RAy9EOXQshT9cMzf1xyEE04'
 
 // Mock useRoute to provide test route parameters and metadata
+let mockToken: string | undefined
 mockNuxtImport('useRoute', () => {
   return () => ({
     params: {
       token: 'dummy-token'
+    },
+    query: {
+      token: mockToken
     },
     meta: {
       checkMagicLink: true
@@ -19,8 +23,13 @@ mockNuxtImport('useRoute', () => {
   })
 })
 
+const mockSwitchAccount = vi.fn()
 mockNuxtImport('useConnectAccountStore', () => () => ({
-  currentAccount: { id: 1234 }
+  switchCurrentAccount: mockSwitchAccount,
+  currentAccount: { id: 1234 },
+  userAccounts: [
+    { id: 1234 }, { id: 5678 }, { id: 9012 }
+  ]
 }))
 
 const mockAuthApi = vi.fn()
@@ -74,6 +83,7 @@ describe('AcceptToken Page', () => {
   // Clear all mock function calls before each test
   beforeEach(() => {
     vi.clearAllMocks()
+    mockToken = undefined
   })
 
   // Helper function to mount component with necessary global plugins and mocks
@@ -115,6 +125,21 @@ describe('AcceptToken Page', () => {
 
       expect(() => component.parseToken('invalid-token'))
         .toThrow('Invalid token format')
+    })
+
+    it('should switch account if fromOrgId is in token', () => {
+      const fromOrgId = 9012
+      mockToken = btoa(JSON.stringify({ ...mockParsedToken, fromOrgId }))
+
+      mountComponent()
+      expect(mockSwitchAccount).toHaveBeenCalledWith(fromOrgId)
+    })
+
+    it('should not switch account if fromOrgId is null', () => {
+      mockToken = btoa(JSON.stringify({ ...mockParsedToken, fromOrgId: null }))
+
+      mountComponent()
+      expect(mockSwitchAccount).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33207

*Description of changes:*
- check fromOrgId in parsed token and switch account on mount


https://github.com/user-attachments/assets/a3f77e76-34f3-4050-8a03-f42f0e5c85ec



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
