### PR TITLE
update pnpm version to latest-11 across CI workflows and package.json…

### DIFF
--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: latest-11
 
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'

--- a/.github/workflows/corps-ci.yaml
+++ b/.github/workflows/corps-ci.yaml
@@ -40,12 +40,12 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v6
       with:
         version: latest-11
         run_install: false
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'
@@ -62,7 +62,7 @@ jobs:
       run: HOME=/root pnpm test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     - name: Upload blob report to GitHub Actions Artifacts
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: blob-report-${{ matrix.shardIndex }}
         path: web/${{ matrix.project }}/blob-report
@@ -80,12 +80,12 @@ jobs:
         working-directory: ./web/${{ matrix.project }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
     - name: Download blob reports from GitHub Actions Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: web/${{ matrix.project }}/all-blob-reports
         pattern: blob-report-*
@@ -95,7 +95,7 @@ jobs:
       run: npx playwright merge-reports --reporter html ./all-blob-reports
 
     - name: Upload HTML report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: html-report--attempt-${{ github.run_attempt }}
         path: web/${{ matrix.project }}/playwright-report

--- a/.github/workflows/corps-ci.yaml
+++ b/.github/workflows/corps-ci.yaml
@@ -20,7 +20,7 @@ jobs:
       working_directory: "./web/corps"
       codecov_flag: "businesscorps"
       node_version: 24
-      pnpm_version: 10.0.0
+      pnpm_version: latest-11
 
   e2e-tests:
     runs-on: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
+        version: latest-11
         run_install: false
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/layers-base-ci.yaml
+++ b/.github/workflows/layers-base-ci.yaml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
+        version: latest-11
         run_install: false
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/layers-base-ci.yaml
+++ b/.github/workflows/layers-base-ci.yaml
@@ -22,12 +22,12 @@ jobs:
       run:
         working-directory: ./packages/layers/${{ matrix.project }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v6
       with:
         version: latest-11
         run_install: false
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'
@@ -57,12 +57,12 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v6
       with:
         version: 10
         run_install: false
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'
@@ -77,7 +77,7 @@ jobs:
       run: HOME=/root pnpm test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     - name: Upload blob report to GitHub Actions Artifacts
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: blob-report-${{ matrix.shardIndex }}
         path: packages/layers/${{ matrix.project }}/blob-report
@@ -95,12 +95,12 @@ jobs:
         working-directory: ./packages/layers/${{ matrix.project }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
     - name: Download blob reports from GitHub Actions Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: packages/layers/${{ matrix.project }}/all-blob-reports
         pattern: blob-report-*
@@ -110,7 +110,7 @@ jobs:
       run: npx playwright merge-reports --reporter html ./all-blob-reports
 
     - name: Upload HTML report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: html-report--attempt-${{ github.run_attempt }}
         path: packages/layers/${{ matrix.project }}/playwright-report

--- a/.github/workflows/person-roles-ci.yaml
+++ b/.github/workflows/person-roles-ci.yaml
@@ -40,12 +40,12 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v6
       with:
         version: latest-11
         run_install: false
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'
@@ -60,7 +60,7 @@ jobs:
       run: HOME=/root pnpm test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     - name: Upload blob report to GitHub Actions Artifacts
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: blob-report-${{ matrix.shardIndex }}
         path: web/${{ matrix.project }}/blob-report
@@ -78,12 +78,12 @@ jobs:
         working-directory: ./web/${{ matrix.project }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
     - name: Download blob reports from GitHub Actions Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: web/${{ matrix.project }}/all-blob-reports
         pattern: blob-report-*
@@ -93,7 +93,7 @@ jobs:
       run: npx playwright merge-reports --reporter html ./all-blob-reports
 
     - name: Upload HTML report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: html-report--attempt-${{ github.run_attempt }}
         path: web/${{ matrix.project }}/playwright-report

--- a/.github/workflows/person-roles-ci.yaml
+++ b/.github/workflows/person-roles-ci.yaml
@@ -20,7 +20,7 @@ jobs:
       working_directory: "./web/person-roles"
       codecov_flag: "personroles"
       node_version: 24
-      pnpm_version: 10.0.0
+      pnpm_version: latest-11
 
   e2e-tests:
     runs-on: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
+        version: latest-11
         run_install: false
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/registry-home-ci.yaml
+++ b/.github/workflows/registry-home-ci.yaml
@@ -40,12 +40,12 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v6
       with:
         version: latest-11
         run_install: false
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'
@@ -60,7 +60,7 @@ jobs:
       run: HOME=/root pnpm test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     - name: Upload blob report to GitHub Actions Artifacts
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: blob-report-${{ matrix.shardIndex }}
         path: web/${{ matrix.project }}/blob-report
@@ -78,12 +78,12 @@ jobs:
         working-directory: ./web/${{ matrix.project }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
     - name: Download blob reports from GitHub Actions Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: web/${{ matrix.project }}/all-blob-reports
         pattern: blob-report-*
@@ -93,7 +93,7 @@ jobs:
       run: npx playwright merge-reports --reporter html ./all-blob-reports
 
     - name: Upload HTML report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: html-report--attempt-${{ github.run_attempt }}
         path: web/${{ matrix.project }}/playwright-report

--- a/.github/workflows/registry-home-ci.yaml
+++ b/.github/workflows/registry-home-ci.yaml
@@ -20,7 +20,7 @@ jobs:
       working_directory: "./web/registry-home"
       codecov_flag: "registryhome"
       node_version: 24
-      pnpm_version: 10.0.0
+      pnpm_version: latest-11
 
   e2e-tests:
     runs-on: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
+        version: latest-11
         run_install: false
     - uses: actions/setup-node@v4
       with:

--- a/packages/layers/base/package.json
+++ b/packages/layers/base/package.json
@@ -28,7 +28,7 @@
     "typecheck": "npx nuxt typecheck"
   },
   "dependencies": {
-    "@sbc-connect/nuxt-pay": "0.4.0",
+    "@sbc-connect/nuxt-pay": "https://pkg.pr.new/@sbc-connect/nuxt-pay@d9fd4b6",
     "http-status-codes": "2.3.0",
     "iso-3166-2": "1.0.0",
     "luxon": "3.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2474,7 +2474,7 @@ packages:
     os: [win32]
 
   '@sbc-connect/nuxt-auth@https://pkg.pr.new/bcgov/connect-nuxt/@sbc-connect/nuxt-auth@d9fd4b6':
-    resolution: {tarball: https://pkg.pr.new/bcgov/connect-nuxt/@sbc-connect/nuxt-auth@d9fd4b6}
+    resolution: {integrity: sha512-189DVO0fWJmG2veWdlgH/9nv0OKobD9OuZD+pSyRBUmVrcvW+Heifals6yb0ua1rFKvwo1ANrmq4ivRf/7BfkA==, tarball: https://pkg.pr.new/bcgov/connect-nuxt/@sbc-connect/nuxt-auth@d9fd4b6}
     version: 0.11.1
 
   '@sbc-connect/nuxt-base@0.10.0':
@@ -2484,7 +2484,7 @@ packages:
     resolution: {integrity: sha512-EkQvALRryLpRkyn9aX1TS1H1D69wAlnBgv+31nfCJmltASrbtu+yD/j3aqJRm8Q92yCJ3aaAtoDbW7u2TfWBFw==}
 
   '@sbc-connect/nuxt-pay@https://pkg.pr.new/@sbc-connect/nuxt-pay@d9fd4b6':
-    resolution: {tarball: https://pkg.pr.new/@sbc-connect/nuxt-pay@d9fd4b6}
+    resolution: {integrity: sha512-KZqruhS70Jja+dzt+plPt/9SxGiSwmVpN2kse2cKa9N+pqu/SsNBIhOpp42RVW+cQmknNFlCcJ/CDeJ+JhyDRQ==, tarball: https://pkg.pr.new/@sbc-connect/nuxt-pay@d9fd4b6}
     version: 0.4.0
 
   '@simple-git/args-pathspec@1.0.3':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
   packages/layers/base:
     dependencies:
       '@sbc-connect/nuxt-pay':
-        specifier: 0.4.0
-        version: 0.4.0(4b595dd112636e0a921daf131d1bf36b)
+        specifier: https://pkg.pr.new/@sbc-connect/nuxt-pay@d9fd4b6
+        version: https://pkg.pr.new/@sbc-connect/nuxt-pay@d9fd4b6(4b595dd112636e0a921daf131d1bf36b)
       http-status-codes:
         specifier: 2.3.0
         version: 2.3.0
@@ -2473,8 +2473,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sbc-connect/nuxt-auth@0.11.1':
-    resolution: {integrity: sha512-/Q+r8eQvogEa7TdircmJEfZfZgFCR4JltW28b8GUgz1VRzVZeDhUSzJ3yWRKYP6RXNfBvdmfE8qnuEkpdkg8Og==}
+  '@sbc-connect/nuxt-auth@https://pkg.pr.new/bcgov/connect-nuxt/@sbc-connect/nuxt-auth@d9fd4b6':
+    resolution: {tarball: https://pkg.pr.new/bcgov/connect-nuxt/@sbc-connect/nuxt-auth@d9fd4b6}
+    version: 0.11.1
 
   '@sbc-connect/nuxt-base@0.10.0':
     resolution: {integrity: sha512-9CyoP9+GRFfF6sUtVosLM2rEApDpvVy21kEVAByQIO8xNIfsN4Rx1FKzrx2h1sHweYQC8qBdXMPxjAMulZKwEg==}
@@ -2482,8 +2483,9 @@ packages:
   '@sbc-connect/nuxt-forms@0.7.5':
     resolution: {integrity: sha512-EkQvALRryLpRkyn9aX1TS1H1D69wAlnBgv+31nfCJmltASrbtu+yD/j3aqJRm8Q92yCJ3aaAtoDbW7u2TfWBFw==}
 
-  '@sbc-connect/nuxt-pay@0.4.0':
-    resolution: {integrity: sha512-btMK2/YTWnWQCYaKfByboZmrQXFtOioYA3E594GEfZYijORUsgkq8T3WYpyouQPcqvw7iM84gXGOkDq7UoUEqA==}
+  '@sbc-connect/nuxt-pay@https://pkg.pr.new/@sbc-connect/nuxt-pay@d9fd4b6':
+    resolution: {tarball: https://pkg.pr.new/@sbc-connect/nuxt-pay@d9fd4b6}
+    version: 0.4.0
 
   '@simple-git/args-pathspec@1.0.3':
     resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
@@ -8942,7 +8944,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
-  '@sbc-connect/nuxt-auth@0.11.1(4b595dd112636e0a921daf131d1bf36b)':
+  '@sbc-connect/nuxt-auth@https://pkg.pr.new/bcgov/connect-nuxt/@sbc-connect/nuxt-auth@d9fd4b6(4b595dd112636e0a921daf131d1bf36b)':
     dependencies:
       '@pinia/colada': 1.3.0(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
       '@pinia/colada-nuxt': 1.0.1(@pinia/colada@1.3.0(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3)))(magicast@0.5.3)
@@ -9158,9 +9160,9 @@ snapshots:
       - yjs
       - yup
 
-  '@sbc-connect/nuxt-pay@0.4.0(4b595dd112636e0a921daf131d1bf36b)':
+  '@sbc-connect/nuxt-pay@https://pkg.pr.new/@sbc-connect/nuxt-pay@d9fd4b6(4b595dd112636e0a921daf131d1bf36b)':
     dependencies:
-      '@sbc-connect/nuxt-auth': 0.11.1(4b595dd112636e0a921daf131d1bf36b)
+      '@sbc-connect/nuxt-auth': https://pkg.pr.new/bcgov/connect-nuxt/@sbc-connect/nuxt-auth@d9fd4b6(4b595dd112636e0a921daf131d1bf36b)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,33 +4,37 @@ packages:
   - web/registry-home
   - packages/**
 
+autoInstallPeers: true
+
 catalog:
   '@axe-core/playwright': 4.11.3
+  '@faker-js/faker': 10.4.0
   '@iconify-json/mdi': 1.2.3
   '@nuxt/test-utils': 3.21.0
+  '@types/node': 25.5.0
   dotenv: 17.4.2
-  typescript: 6.0.3
-  vue-tsc: 3.3.1
   nuxt: 4.4.6
+  typescript: 6.0.3
   vue: 3.5.34
   vue-router: 5.0.7
-  '@types/node': 25.5.0
-  '@faker-js/faker': 10.4.0
+  vue-tsc: 3.3.1
 
 minimumReleaseAge: 4320 # 3 days
 minimumReleaseAgeExclude:
-- '@sbc-connect/*'
-autoInstallPeers: true
-shamefullyHoist: true
+  - '@sbc-connect/*'
 
-onlyBuiltDependencies:
-  - "@parcel/watcher"
-  - "@sbc-connect/nuxt-auth"
-  - "@sbc-connect/nuxt-base"
-  - "@sbc-connect/nuxt-business-base"
-  - "@sbc-connect/nuxt-forms"
-  - "@sbc-connect/nuxt-pay"
-  - "@tailwindcss/oxide"
-  - "esbuild"
-  - "vue-demi"
-  - "unrs-resolver"
+# pnpm v11 replaced onlyBuiltDependencies / neverBuiltDependencies / ignoredBuiltDependencies
+# with a single allowBuilds map. true = run install scripts, false = skip them.
+allowBuilds:
+  '@parcel/watcher': true
+  '@sbc-connect/nuxt-auth': true
+  '@sbc-connect/nuxt-base': true
+  '@sbc-connect/nuxt-business-base': true
+  '@sbc-connect/nuxt-forms': true
+  '@sbc-connect/nuxt-pay': true
+  '@tailwindcss/oxide': true
+  esbuild: true
+  unrs-resolver: true
+  vue-demi: true
+
+shamefullyHoist: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,11 @@ minimumReleaseAge: 4320 # 3 days
 minimumReleaseAgeExclude:
   - '@sbc-connect/*'
 
+# Allow exotic (URL/tarball) sources in transitive deps. Required because the
+# @sbc-connect/* preview packages from pkg.pr.new reference each other via URL
+# (e.g. nuxt-pay -> nuxt-auth). Default is true since pnpm v10.26.0.
+blockExoticSubdeps: false
+
 # pnpm v11 replaced onlyBuiltDependencies / neverBuiltDependencies / ignoredBuiltDependencies
 # with a single allowBuilds map. true = run install scripts, false = skip them.
 allowBuilds:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,11 +7,11 @@ packages:
 autoInstallPeers: true
 
 catalog:
-  '@axe-core/playwright': 4.11.3
-  '@faker-js/faker': 10.4.0
-  '@iconify-json/mdi': 1.2.3
-  '@nuxt/test-utils': 3.21.0
-  '@types/node': 25.5.0
+  "@axe-core/playwright": 4.11.3
+  "@faker-js/faker": 10.4.0
+  "@iconify-json/mdi": 1.2.3
+  "@nuxt/test-utils": 3.21.0
+  "@types/node": 25.5.0
   dotenv: 17.4.2
   nuxt: 4.4.6
   typescript: 6.0.3
@@ -21,7 +21,7 @@ catalog:
 
 minimumReleaseAge: 4320 # 3 days
 minimumReleaseAgeExclude:
-  - '@sbc-connect/*'
+  - "@sbc-connect/*"
 
 # Allow exotic (URL/tarball) sources in transitive deps. Required because the
 # @sbc-connect/* preview packages from pkg.pr.new reference each other via URL
@@ -31,13 +31,13 @@ blockExoticSubdeps: false
 # pnpm v11 replaced onlyBuiltDependencies / neverBuiltDependencies / ignoredBuiltDependencies
 # with a single allowBuilds map. true = run install scripts, false = skip them.
 allowBuilds:
-  '@parcel/watcher': true
-  '@sbc-connect/nuxt-auth': true
-  '@sbc-connect/nuxt-base': true
-  '@sbc-connect/nuxt-business-base': true
-  '@sbc-connect/nuxt-forms': true
-  '@sbc-connect/nuxt-pay': true
-  '@tailwindcss/oxide': true
+  "@parcel/watcher": true
+  "@sbc-connect/nuxt-auth": true
+  "@sbc-connect/nuxt-base": true
+  "@sbc-connect/nuxt-business-base": true
+  "@sbc-connect/nuxt-forms": true
+  "@sbc-connect/nuxt-pay": true
+  "@tailwindcss/oxide": true
   esbuild: true
   unrs-resolver: true
   vue-demi: true

--- a/web/corps/README.md
+++ b/web/corps/README.md
@@ -1,6 +1,7 @@
 # Corps UI
 
 ## Tech
+
 - Framework: [Nuxt 4](https://nuxt.com/)
 - UI Library: [Nuxt UI v4](https://ui.nuxt.com/)
 
@@ -9,6 +10,7 @@
 Please review the [Code of Conduct](./CODE_OF_CONDUCT.md) and [Contributing](./CONTRIBUTING.md) guidelines before contributing to this project to ensure a positive and productive experience for everyone.
 
 Create a fork and local copy of this repo. Answer _Y_ to create a local clone.
+
 ```bash
 gh repo fork bcgov/business-ui
 ```
@@ -16,12 +18,14 @@ gh repo fork bcgov/business-ui
 > [!IMPORTANT]
 > Ensure you have the env variables as defined in the `.env.example` file.
 Change into the directory and install the packages.
+
 ```bash
 cd bcgov/business-ui/corps
 pnpm install
 ```
 
 Startup the development environment.
+
 ```bash
 pnpm run dev
 ```
@@ -29,11 +33,13 @@ pnpm run dev
 ## Build and Preview
 
 Build the static site
+
 ```bash
 pnpm run generate
 ```
 
 Locally preview the static site
+
 ```bash
 npx serve .output/public
 ```
@@ -51,11 +57,13 @@ Unit testing is configured to use the following libraries:
 - [Vue Test Utils](https://test-utils.vuejs.org/guide/) - test utils
 
 To run Vitest:
+
 ```bash
 pnpm test:unit
 ```
 
 To run Vitest Coverage:
+
 ```bash
 pnpm test:unit:cov
 ```
@@ -70,11 +78,13 @@ Unit testing is configured to use the following libraries:
 **Please use [Faker](https://fakerjs.dev/guide/) to generate unique test data**
 
 To run Playwright in the terminal:
+
 ```bash
 pnpm test:e2e
 ```
 
 To run Playwright in ui mode:
+
 ```bash
 pnpm test:e2e:ui
 ```
@@ -82,11 +92,13 @@ pnpm test:e2e:ui
 #### Playwright Config
 
 The globalSetup option will create and save an auth user state which can then be used inside other tests:
+
 ```js
   globalSetup: './tests/e2e/setup',
 ```
 
 To use this auth state:
+
 ```js
   test.describe('Describe Block', () => {
     test.use({ storageState: `tests/e2e/.auth/bcsc-user.json` })
@@ -98,6 +110,7 @@ To use this auth state:
 ```
 
 To run tests in headless mode, set the headless property in the Playwright config:
+
 ```js
   use: {
     headless: true

--- a/web/corps/package.json
+++ b/web/corps/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.13.1",
+  "packageManager": "pnpm@11.5.1",
   "license": "BSD-3-Clause",
   "scripts": {
     "build-check": "nuxt build",

--- a/web/person-roles/package.json
+++ b/web/person-roles/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.13.1",
+  "packageManager": "pnpm@11.5.1",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/web/registry-home/package.json
+++ b/web/registry-home/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.13.1",
+  "packageManager": "pnpm@11.5.1",
   "license": "BSD-3-Clause",
   "scripts": {
     "build-check": "nuxt build",


### PR DESCRIPTION
This pull request upgrades the project from pnpm v10 to pnpm v11 across all relevant CI workflows and package configurations. It also updates the `pnpm-workspace.yaml` file to align with pnpm v11's new settings, including changes to dependency build controls. These updates ensure compatibility with the latest pnpm features and maintain consistency across the monorepo.

**pnpm v11 Upgrade and Configuration Updates:**

* Updated all CI workflow files (such as `.github/workflows/corps-ci.yaml`, `person-roles-ci.yaml`, and `registry-home-ci.yaml`) to use `pnpm` version `latest-11` instead of v10, ensuring CI runs with the latest major version. 

**Workspace and Dependency Management:**

* Refactored `pnpm-workspace.yaml` to use pnpm v11's new `allowBuilds` map, replacing the deprecated `onlyBuiltDependencies`, `neverBuiltDependencies`, and `ignoredBuiltDependencies` fields. This controls which dependencies have build scripts run during install.
* Moved and sorted dependency versions in the `catalog` section for clarity and consistency, and restored the `shamefullyHoist` and `autoInstallPeers` flags for workspace compatibility.… files

*Issue #:* /bcgov/entity###

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-ui license (BSD 3-Clause).
