### PR TITLE
32865 Add the authorization to the correction submission

### DIFF
--- a/packages/layers/base/app/components/Form/Certify/index.vue
+++ b/packages/layers/base/app/components/Form/Certify/index.vue
@@ -26,7 +26,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="space-y-6 bg-shade rounded p-6">
+  <div class="space-y-6 bg-shade rounded pt-6">
     <div class="space-y-2">
       <h2>{{ props.order ? `${props.order}. ${$t('label.certify')}` : $t('label.certify') }}</h2>
       <p>
@@ -35,7 +35,7 @@ defineExpose({
     </div>
     <UForm
       ref="certify-form"
-      class="bg-white rounded"
+      class="bg-white rounded w-full"
       :schema="certifySchema"
       nested
       :name

--- a/packages/layers/base/app/components/Form/ConfirmAuthorization/index.vue
+++ b/packages/layers/base/app/components/Form/ConfirmAuthorization/index.vue
@@ -26,7 +26,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="space-y-6 bg-shade rounded p-6">
+  <div class="space-y-6 bg-shade rounded pt-6">
     <div class="space-y-2">
       <h2>
         {{ props.order ? `${props.order}. ${$t('label.confirmAuthorization')}` : $t('label.confirmAuthorization') }}
@@ -37,7 +37,7 @@ defineExpose({
     </div>
     <UForm
       ref="confirm-authorization-form"
-      class="bg-white rounded"
+      class="bg-white rounded w-full"
       :schema="confirmAuthorizationSchema"
       nested
       :name

--- a/web/corps/app/components/Form/Correction/Step2.vue
+++ b/web/corps/app/components/Form/Correction/Step2.vue
@@ -2,6 +2,7 @@
 import type { FormErrorEvent } from '@nuxt/ui'
 import { z } from 'zod'
 import { CORRECTION_DETAIL_COMMENT_MAX_LENGTH } from '~/utils/schemas/correction'
+import { CORPS } from '~/utils'
 
 const store = useCorrectionStore()
 const businessStore = useBusinessStore()
@@ -42,6 +43,11 @@ const hasReceiverChanges = computed(() => {
 /** Whether any liquidators were changed */
 const hasLiquidatorChanges = computed(() => {
   return store.liquidators.some(l => l.new.actions.length > 0)
+})
+
+const requiresAuthorization = computed(() => {
+  const legalType = businessStore.business?.legalType as CorpTypeCd | undefined
+  return legalType ? CORPS.includes(legalType) : false
 })
 
 function onError(event: FormErrorEvent) {
@@ -175,12 +181,20 @@ function onError(event: FormErrorEvent) {
       name="certify"
     />
 
+    <FormConfirmAuthorization
+      v-if="requiresAuthorization && store.formState.authorization"
+      v-model="store.formState.authorization"
+      :entity-type="getLegalTypeDescription(businessStore.business?.legalType)"
+      :order="store.isStaffCorrectionType ? 4 : 6"
+      name="authorization"
+    />
+
     <!-- Staff Payment (always present, order is dynamic) -->
     <StaffPaymentFieldset
       v-if="store.formState.staffPayment"
       ref="staff-pay-ref"
       v-model="store.formState.staffPayment"
-      :order="store.isStaffCorrectionType ? 4 : 6"
+      :order="store.isStaffCorrectionType ? 5 : 7"
       :initializing="store.initializing"
     />
   </UForm>

--- a/web/corps/app/stores/correction.ts
+++ b/web/corps/app/stores/correction.ts
@@ -137,6 +137,11 @@ export const useCorrectionStore = defineStore('correction-store', () => {
       if (formState.certify) {
         formState.certify.legalName = header.certifiedBy ?? ''
       }
+      if (formState.authorization) {
+        formState.authorization.isAuthorized = Boolean(
+          (draftFiling.filing.header as { authorizationReceived?: boolean }).authorizationReceived
+        )
+      }
 
       // Completing party (client corrections only) — read from relationships (new format)
       // The draft may contain multiple relationships with a "Completing Party" role:
@@ -379,14 +384,17 @@ export const useCorrectionStore = defineStore('correction-store', () => {
       // as correction sections are implemented in the UI
     }
 
+    const headerPayload = {
+      ...formatStaffPaymentApi(formState.staffPayment!),
+      ...(formState.certify?.legalName ? { certifiedBy: formState.certify.legalName } : {}),
+      authorizationReceived: Boolean(formState.authorization?.isAuthorized)
+    }
+
     const filingPayload = createFilingPayload(
       businessStore.business!,
       FilingType.CORRECTION,
       { correction: correctionPayload },
-      {
-        ...formatStaffPaymentApi(formState.staffPayment!),
-        ...(formState.certify?.legalName ? { certifiedBy: formState.certify.legalName } : {})
-      }
+      headerPayload
     )
 
     // Draft is always pre-created, so we always have a filingId to update

--- a/web/corps/app/stores/correction.ts
+++ b/web/corps/app/stores/correction.ts
@@ -134,14 +134,6 @@ export const useCorrectionStore = defineStore('correction-store', () => {
       if (draft.courtOrder) {
         formState.courtOrder = formatCourtOrderUi(draft.courtOrder)
       }
-      if (formState.certify) {
-        formState.certify.legalName = header.certifiedBy ?? ''
-      }
-      if (formState.authorization) {
-        formState.authorization.isAuthorized = Boolean(
-          (draftFiling.filing.header as { authorizationReceived?: boolean }).authorizationReceived
-        )
-      }
 
       // Completing party (client corrections only) — read from relationships (new format)
       // The draft may contain multiple relationships with a "Completing Party" role:
@@ -396,6 +388,13 @@ export const useCorrectionStore = defineStore('correction-store', () => {
       { correction: correctionPayload },
       headerPayload
     )
+
+    const header = filingPayload.filing.header as Record<string, unknown>
+    // remove certifiedBy and authorizationReceived from header if not a submission (i.e. if saving as draft)
+    if (!isSubmission) {
+      delete header.certifiedBy
+      delete header.authorizationReceived
+    }
 
     // Draft is always pre-created, so we always have a filingId to update
     const filingId = draftFilingState.value?.filing?.header?.filingId

--- a/web/corps/app/utils/corp-info.ts
+++ b/web/corps/app/utils/corp-info.ts
@@ -1,3 +1,15 @@
+// Authorization is only required for Corporations
+export const CORPS: CorpTypeCd[] = [
+  CorpTypeCd.BENEFIT_COMPANY,
+  CorpTypeCd.BC_COMPANY,
+  CorpTypeCd.BC_CCC,
+  CorpTypeCd.BC_ULC_COMPANY,
+  CorpTypeCd.BEN_CONTINUE_IN,
+  CorpTypeCd.CONTINUE_IN,
+  CorpTypeCd.CCC_CONTINUE_IN,
+  CorpTypeCd.ULC_CONTINUE_IN
+]
+
 export function getLegalTypeDescription(legalType?: string | null): string {
   if (!legalType) {
     return ''

--- a/web/corps/app/utils/schemas/correction.ts
+++ b/web/corps/app/utils/schemas/correction.ts
@@ -18,10 +18,15 @@ function getClientCorrectionSchema() {
         locationDescription: ''
       }
     })),
-    certify: getCertifySchema().default({
+    certify: getCertifySchema().extend({
+      legalName: z.string()
+    }).default({
       isCertified: false,
       legalName: ''
-    })
+    }),
+    authorization: getConfirmAuthorizationSchema().default(() => ({
+      isAuthorized: false
+    }))
   })
 }
 

--- a/web/corps/package.json
+++ b/web/corps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corps",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "engines": {

--- a/web/corps/tests/e2e/specs/correction/page-init.spec.ts
+++ b/web/corps/tests/e2e/specs/correction/page-init.spec.ts
@@ -182,8 +182,33 @@ test.describe('Correction - Page init', () => {
       // Completing party and certify should be visible for client corrections
       await expect(page.getByTestId('completing-party-section')).toBeVisible({ timeout: 10000 })
       await expect(page.getByTestId('certify-section')).toBeVisible()
+      // Confirm authorization should be visible for corp legal types
+      await expect(page.getByTestId('confirm-authorization-section')).toBeVisible()
       // Staff payment is always present
       await expect(page.getByTestId('staff-payment-section')).toBeVisible()
+    })
+
+    test('should show confirm authorization section on step 2 for corp corrections', async ({ page }) => {
+      await setupCorrectionPage(page, identifier, filingId, CRCTN_NO_FEE, 'STAFF', 'STAFF')
+      await navigateToCorrectionPage(page, identifier, filingId)
+      await page.waitForLoadState('networkidle')
+
+      await expect(page.getByText(/loading/i)).not.toBeVisible({ timeout: 15000 })
+
+      // Section should not be visible before moving to step 2
+      await expect(page.getByTestId('confirm-authorization-section')).not.toBeVisible()
+
+      // Make a change to navigate to step 2
+      await makeDirectorEdit(page, 'Corrected Unit')
+      await page.getByRole('button', { name: 'Review and Confirm' }).click()
+
+      // Confirm authorization should be shown on step 2 for corp legal types
+      await expect(page.getByTestId('confirm-authorization-section')).toBeVisible({ timeout: 10000 })
+      await expect(
+        page.getByTestId('confirm-authorization-section').getByRole('checkbox', {
+          name: /i confirm that the information provided is correct/i
+        })
+      ).toBeVisible()
     })
 
     test('should show staff payment on step 2 for staff users', async ({ page }) => {

--- a/web/corps/tests/e2e/specs/correction/submit.spec.ts
+++ b/web/corps/tests/e2e/specs/correction/submit.spec.ts
@@ -38,6 +38,14 @@ async function fillCompletingParty(page: Page) {
   await page.getByTestId('completing-party-email-input').fill('correction-test@example.com')
 }
 
+async function fillConfirmAuthorization(page: Page) {
+  const confirmAuthorizationSection = page.getByTestId('confirm-authorization-section')
+  await expect(confirmAuthorizationSection).toBeVisible()
+  await confirmAuthorizationSection.getByRole('checkbox', {
+    name: /i confirm that the information provided is correct/i
+  }).click()
+}
+
 test.describe('Correction - Filing Submit', () => {
   test.describe('Staff correction', () => {
     test('should submit a staff correction with director changes', async ({ page }) => {
@@ -63,6 +71,9 @@ test.describe('Correction - Filing Submit', () => {
 
       // Fill completing party email
       await fillCompletingParty(page)
+
+      // Confirm authorization is required for corp legal types
+      await fillConfirmAuthorization(page)
 
       // Select staff payment option (required for form validation)
       await page.getByRole('radio', { name: 'No Fee' }).click()
@@ -197,6 +208,9 @@ test.describe('Correction - Filing Submit', () => {
       // Certify section should be visible for client corrections
       await expect(page.getByTestId('certify-section')).toBeVisible()
 
+      // Confirm authorization should be visible for corp legal types
+      await expect(page.getByTestId('confirm-authorization-section')).toBeVisible()
+
       // Staff payment should be visible
       await expect(page.getByTestId('staff-payment-section')).toBeVisible()
 
@@ -242,6 +256,9 @@ test.describe('Correction - Filing Submit', () => {
       // Fill certify: checkbox is required by the updated certify component
       const certifySection = page.getByTestId('certify-section')
       await certifySection.getByRole('checkbox', { name: /certify/i }).check({ force: true })
+
+      // Fill confirm authorization
+      await fillConfirmAuthorization(page)
 
       // Select staff payment option
       await page.getByRole('radio', { name: 'No Fee' }).click()

--- a/web/corps/tests/e2e/specs/correction/submit.spec.ts
+++ b/web/corps/tests/e2e/specs/correction/submit.spec.ts
@@ -144,6 +144,10 @@ test.describe('Correction - Filing Submit', () => {
       expect(requestBody.filing.correction).toBeDefined()
       expect(requestBody.filing.correction.correctedFilingId).toBe(111554)
 
+      // Draft saves should not persist certify or authorization form values in the header
+      expect(requestBody.filing.header).not.toHaveProperty('authorizationReceived')
+      expect(requestBody.filing.header).not.toHaveProperty('certifiedBy')
+
       // Verify it was sent as a draft (not a submission)
       expect(request.url()).toContain('draft=true')
     })


### PR DESCRIPTION
*Issue #:* /bcgov/entity###
https://github.com/bcgov/entity/issues/32865

*Description of changes:*
1. align Certify and Authorization to other components in the filing
2. Add the authorization component to correction filing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-ui license (BSD 3-Clause).
