### PR TITLE
33787: update completed Continuation Out text

### DIFF
--- a/.changeset/33787-continuation-out-wording.md
+++ b/.changeset/33787-continuation-out-wording.md
@@ -1,0 +1,5 @@
+---
+"@sbc-connect/nuxt-business-base": patch
+---
+
+Update completed Continuation Out text to state the corporation is no longer a company in British Columbia under the Business Corporations Act.

--- a/packages/layers/base/i18n/locales/en-CA.ts
+++ b/packages/layers/base/i18n/locales/en-CA.ts
@@ -728,7 +728,7 @@ export default {
     systemCompletedProcessingFiling: 'The system has completed processing your filing. You can now retrieve the business information.',
     ThisCompany: 'This company',
     theCompanyWasSuccessfullyAmalgamatedOut: 'The Company {name} was successfully {boldStart}Amalgamated Out on {date}, to {foreignjurisdiction} under the name "{newname}"{boldEnd}. The Company has been struck from the register and ceased to be an incorporated company under the Business Corporations Act. You are required to retain a copy of all the Amalgamation Out documents in your records books.',
-    theCompanyWasSuccessfullyContinuedOut: 'The Company {name} was successfully {boldStart}Continued Out on {date}, to {foreignjurisdiction} under the name "{newname}"{boldEnd}. The Company has been struck from the register and ceased to be an incorporated company under the Business Corporations Act. You are required to retain a copy of all the Continuation Out documents in your records books.',
+    theCompanyWasSuccessfullyContinuedOut: 'The Company {name} was successfully {boldStart}Continued Out on {date}, to {foreignjurisdiction} under the name "{newname}"{boldEnd}. This corporation is no longer a company in British Columbia under the {italicStart}Business Corporations Act{italicEnd}. You are required to retain a copy of all the Continuation Out documents in your records books.',
     thisCompany: 'this company',
     thisConsentToIsValidUntilDate: 'This consent to {name} to {foreignjurisdiction} is valid {boldStart}until {date}{boldEnd}.',
     undefinedStaffRejectionMessage: 'Staff rejection message unavailable',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33787

*Description of changes:*
The Continuation Out completed-filing wording was updated in the shared @sbc-connect/nuxt-business-base layer (published from the bcgov/business-ui repo), so bcgov/person-search needs to bump its @sbc-connect/nuxt-business-base dependency in bor-ui/package.json from 0.21.1 to the newly published version to reference the correct package and pick up the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-ui license (BSD 3-Clause).
