### PR TITLE
[TEST] pnpm v11 upgrade - CI validation

### DIFF
--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -1,0 +1,37 @@
+name: "[TEST] pnpm v11 upgrade - business-ui apps"
+on:
+  push:
+    branches: ["test/pnpm-v11-upgrade"]
+  workflow_dispatch:
+
+jobs:
+  test-pnpm-v11:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - web/corps
+          - web/registry-home
+          - web/person-roles
+          - web/business-registry-dashboard
+    defaults:
+      run:
+        working-directory: ${{ matrix.app }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup pnpm v11
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest-11
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: ${{ matrix.app }}/pnpm-lock.yaml
+      - name: Install
+        run: pnpm install
+      - name: Build
+        run: pnpm build
+      - name: Verify pnpm version
+        run: pnpm --version


### PR DESCRIPTION
## Test PR — do not merge

This PR exists solely to trigger CI and validate that pnpm v11 is compatible.

- Runs `test-pnpm-v11.yml` (or `test-pnpm-v11-ci.yml`) which uses `pnpm@latest-11`
- Does **not** modify any existing CI workflows
- Will be closed once CI passes and the real upgrade PRs are merged

> Ticket: #33875