### PR TITLE
33873-filing-detail-comment-type

### DIFF
--- a/.changeset/33873-filing-detail-comments.md
+++ b/.changeset/33873-filing-detail-comments.md
@@ -1,0 +1,5 @@
+---
+"@sbc-connect/nuxt-business-base": minor
+---
+
+Show comments that are part of a filing in their own Filing Detail section in the business ledger, separate from staff detail comments and excluded from the Details count.

--- a/packages/layers/base/app/components/BusinessLedger/Item/Body/Details/Index.vue
+++ b/packages/layers/base/app/components/BusinessLedger/Item/Body/Details/Index.vue
@@ -5,7 +5,7 @@ const isCommentOpen = ref(false)
 
 const filing = inject<BusinessLedgerItem>('filing')!
 
-const { comments } = useBusinessLedger(filing)
+const { detailComments } = useBusinessLedger(filing)
 
 // FUTURE: add in staff add comment ability
 const isDisableNonBenCorps = () => false
@@ -27,7 +27,7 @@ const showCommentDialog = (show: boolean) => {
             size="large"
           />
           <span class="ml-1">
-            {{ $t('label.details') }} ({{ comments.length || 0 }})
+            {{ $t('label.details') }} ({{ detailComments.length || 0 }})
           </span>
         </strong>
       </div>
@@ -45,7 +45,7 @@ const showCommentDialog = (show: boolean) => {
     <!-- the detail comments list -->
     <div class="mt-3 space-y-5 text-sm">
       <div
-        v-for="(comment, index) in comments"
+        v-for="(comment, index) in detailComments"
         :key="index"
         data-testid="ledger-comment"
       >

--- a/packages/layers/base/app/components/BusinessLedger/Item/Body/FilingDetails/Index.vue
+++ b/packages/layers/base/app/components/BusinessLedger/Item/Body/FilingDetails/Index.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+const filing = inject<BusinessLedgerItem>('filing')!
+
+// the comments that are part of the filing
+const { filingDetailComments } = useBusinessLedger(filing)
+</script>
+
+<template>
+  <div class="space-y-4" data-testid="filing-details">
+    <p
+      v-for="(comment, index) in filingDetailComments"
+      :key="index"
+      class="whitespace-pre-line break-words"
+      data-testid="filing-detail"
+    >
+      <strong>{{ $t('label.filingDetail') }}</strong>: {{ comment.comment }}
+    </p>
+  </div>
+</template>

--- a/packages/layers/base/app/components/BusinessLedger/Item/Body/Index.vue
+++ b/packages/layers/base/app/components/BusinessLedger/Item/Body/Index.vue
@@ -3,6 +3,7 @@ defineProps<{ loading: boolean }>()
 const showDocumentRecords = inject<Ref<boolean>>('showDocumentRecords')
 
 const filing = inject<BusinessLedgerItem>('filing')!
+const { detailComments, filingDetailComments } = useBusinessLedger(filing)
 const drsStore = useDocumentRecordServiceStore()
 const documentId = ref<string | undefined>(undefined)
 
@@ -23,6 +24,7 @@ onMounted(async () => {
     data-testid="business-ledger-item-body"
   >
     <BusinessLedgerItemBodyText />
+    <BusinessLedgerItemBodyFilingDetails v-if="filingDetailComments.length" />
     <div v-if="loading" class="space-y-3">
       <USkeleton class="h-5 w-50 rounded" />
       <USkeleton class="h-5 w-50 rounded" />
@@ -32,7 +34,7 @@ onMounted(async () => {
       <BusinessLedgerItemBodyDocuments v-if="!filing.availableOnPaperOnly" />
       <BusinessLedgerItemBodyDocumentsRecordButton v-if="documentId" :document-id="documentId" />
       <BusinessLedgerItemBodyDetails
-        v-if="filing.commentsCount"
+        v-if="detailComments.length"
         :class="{ 'border-t border-line-muted mt-6 pt-6': !filing.availableOnPaperOnly || documentId }"
       />
     </div>

--- a/packages/layers/base/app/components/BusinessLedger/Item/Index.vue
+++ b/packages/layers/base/app/components/BusinessLedger/Item/Index.vue
@@ -12,6 +12,7 @@ provide<BusinessLedgerItem>('filing', props.filing)
 const overrideGetFilingDocumentsFn = inject<OverrideGetFilingDocumentUrlsFn>('overrideGetFilingDocumentsFn')
 
 const {
+  filingDetailComments,
   isFilingStatus,
   isFilingType,
   isCourtOrder,
@@ -25,6 +26,9 @@ const { getFilingName } = useFiling()
 
 const showBody = ref(false)
 const loadingDetails = ref(false)
+
+// the Details count shows staff comments only; the filing's own comments are shown separately
+const detailCommentsCount = computed(() => props.filing.commentsCount - filingDetailComments.value.length)
 
 const toggleDetails = async () => {
   loadingDetails.value = true
@@ -54,6 +58,9 @@ const actionBtnLabel = computed(() => (
 onMounted(() => {
   if (props.setExpanded) {
     toggleDetails()
+  } else {
+    // load the comments so the Details count is correct before the item is opened
+    loadComments()
   }
 })
 </script>
@@ -82,9 +89,9 @@ onMounted(() => {
         </div>
         <div>
           <UButton
-            v-if="filing.commentsCount > 0"
+            v-if="detailCommentsCount > 0"
             class="px-0 shrink"
-            :label="`${$t('label.details')} (${filing.commentsCount})`"
+            :label="`${$t('label.details')} (${detailCommentsCount})`"
             leading-icon="i-mdi-message-text-outline"
             :loading="loadingDetails"
             variant="link"

--- a/packages/layers/base/app/composables/useBusinessLedger.ts
+++ b/packages/layers/base/app/composables/useBusinessLedger.ts
@@ -187,10 +187,20 @@ export const useBusinessLedger = (filing: BusinessLedgerItem) => {
   }
 
   const comments = computed(() => ledgerItem.value.comments || [])
+  // comments that are part of the filing
+  const filingDetailComments = computed(() =>
+    comments.value.filter(comment => comment.commentType === CommentType.FILING)
+  )
+  // comments added by staff
+  const detailComments = computed(() =>
+    comments.value.filter(comment => comment.commentType !== CommentType.FILING)
+  )
   const documents = computed(() => ledgerItem.value.documents || [])
 
   return {
     comments,
+    detailComments,
+    filingDetailComments,
     documents,
     foreignJurisdiction,
     isChangeOfOfficers,

--- a/packages/layers/base/app/enums/comment-type.ts
+++ b/packages/layers/base/app/enums/comment-type.ts
@@ -1,0 +1,4 @@
+export enum CommentType {
+  FILING = 'FILING', // part of the filing
+  STAFF = 'STAFF' // added by staff
+}

--- a/packages/layers/base/app/interfaces/business-comment.ts
+++ b/packages/layers/base/app/interfaces/business-comment.ts
@@ -1,6 +1,7 @@
 export interface BusinessComment {
   businessId?: string
   comment: string
+  commentType?: CommentType
   filingId?: string
   submitterDisplayName: string
   timestamp: string

--- a/packages/layers/base/i18n/locales/en-CA.ts
+++ b/packages/layers/base/i18n/locales/en-CA.ts
@@ -401,6 +401,7 @@ export default {
     deliveryAddressSameAsMailing: 'Delivery Address same as Mailing Address',
     detail: 'Detail',
     details: 'Details',
+    filingDetail: 'Filing Detail',
     director: 'Director',
     directors: 'Directors',
     dissolutionCompleted: 'Dissolution Completed',

--- a/packages/layers/base/tests/unit/composables/useBusinessLedger.spec.ts
+++ b/packages/layers/base/tests/unit/composables/useBusinessLedger.spec.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { CommentType } from '#imports'
+
+const mockBusinessService = {
+  getFilingComments: vi.fn(),
+  getFilingDocumentUrls: vi.fn()
+}
+mockNuxtImport('useBusinessService', () => () => mockBusinessService)
+
+/** Builds a comment of the given type. */
+const buildComment = (commentType: CommentType | undefined, comment = 'text') => ({
+  comment,
+  commentType,
+  submitterDisplayName: 'BC Registries Staff',
+  timestamp: '2025-10-14T14:11:20.310185+00:00'
+})
+
+/** Builds a minimal ledger item; each test uses a unique filingId to keep them separate. */
+const buildFiling = (filingId: number, comments: Array<ReturnType<typeof buildComment>>) =>
+  ({ filingId, comments } as unknown as BusinessLedgerItem)
+
+describe('useBusinessLedger - filing detail comments', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  test('splits FILING comments out of the detail comments', () => {
+    const filing = buildFiling(1001, [
+      buildComment(CommentType.STAFF, 'staff note'),
+      buildComment(CommentType.FILING, 'filing detail'),
+      buildComment(CommentType.STAFF, 'another staff note')
+    ])
+
+    const { filingDetailComments, detailComments } = useBusinessLedger(filing)
+
+    expect(filingDetailComments.value.map(c => c.comment)).toEqual(['filing detail'])
+    expect(detailComments.value.map(c => c.comment)).toEqual(['staff note', 'another staff note'])
+  })
+
+  test('returns every FILING comment (eg, a correction records two)', () => {
+    const filing = buildFiling(1002, [
+      buildComment(CommentType.FILING, 'This filing was corrected on 2025-10-14.'),
+      buildComment(CommentType.FILING, 'Reason for the correction.')
+    ])
+
+    const { filingDetailComments, detailComments } = useBusinessLedger(filing)
+
+    expect(filingDetailComments.value).toHaveLength(2)
+    expect(detailComments.value).toHaveLength(0)
+  })
+
+  test('treats comments with no commentType as detail comments', () => {
+    const filing = buildFiling(1003, [buildComment(undefined, 'legacy comment')])
+
+    const { filingDetailComments, detailComments } = useBusinessLedger(filing)
+
+    expect(filingDetailComments.value).toHaveLength(0)
+    expect(detailComments.value.map(c => c.comment)).toEqual(['legacy comment'])
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33873

*Description of changes:*
Filing comments are now shown in their own "Filing Detail" section in the business ledger, separate from staff comments and excluded from the Details count.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-ui license (BSD 3-Clause).
