### PR TITLE
34275 -  resolution dates correction transition

### DIFF
--- a/.changeset/large-drinks-camp.md
+++ b/.changeset/large-drinks-camp.md
@@ -1,0 +1,5 @@
+---
+"@sbc-connect/nuxt-business-base": minor
+---
+
+Minor styling updates in ShareStructure and Business table components. Resolution date formatters'

--- a/packages/layers/base/app/components/Form/Share/ResolutionDate/index.vue
+++ b/packages/layers/base/app/components/Form/Share/ResolutionDate/index.vue
@@ -34,6 +34,16 @@ async function onDone() {
     onFormSubmitError(e as FormErrorEvent)
   }
 }
+
+watch(
+  [() => props.standalone, model],
+  ([isStandalone, val]) => {
+    if (isStandalone && val) {
+      val.actions = [ActionType.ADDED]
+    }
+  },
+  { immediate: true }
+)
 </script>
 
 <template>

--- a/packages/layers/base/app/components/ManageShareStructure/index.vue
+++ b/packages/layers/base/app/components/ManageShareStructure/index.vue
@@ -299,7 +299,7 @@ const addResolutionDateValidationContext = computed(() => ({
 
 watch(requiresResolutionDate, (v) => {
   if (v) {
-    resolutionDate.value = getResolutionDateSchema().parse({})
+    resolutionDate.value = getResolutionDateSchema().parse(toRaw(resolutionDate.value) ?? {})
   } else {
     resolutionDate.value = undefined
   }
@@ -454,9 +454,11 @@ watch(requiresResolutionDate, (v) => {
       </template>
       <ConnectFieldset
         v-if="existingResolutionDates.length > 0"
-        :label="requiresResolutionDate
-          ? $t('label.previousDates')
-          : $t('label.previousResolutionOrCourtOrderDatesRegardingShares')
+        :label="isReadOnly
+          ? $t('label.resolutionsOrCourtOrdersRegardingShares')
+          : requiresResolutionDate
+            ? $t('label.previousDates')
+            : $t('label.previousResolutionOrCourtOrderDatesRegardingShares')
         "
         padding-class="xy-default"
       >

--- a/packages/layers/base/app/components/ManageShareStructure/index.vue
+++ b/packages/layers/base/app/components/ManageShareStructure/index.vue
@@ -303,7 +303,7 @@ watch(requiresResolutionDate, (v) => {
   } else {
     resolutionDate.value = undefined
   }
-})
+}, { immediate: true })
 </script>
 
 <template>
@@ -427,7 +427,7 @@ watch(requiresResolutionDate, (v) => {
 
     <div
       v-if="requiresResolutionDate || existingResolutionDates.length > 0"
-      class="w-full rounded-md ring ring-default"
+      class="w-full rounded-md ring ring-default bg-white"
     >
       <template v-if="requiresResolutionDate && resolutionDate">
         <ConnectFieldset
@@ -445,6 +445,7 @@ watch(requiresResolutionDate, (v) => {
               v-model="resolutionDate"
               variant="add"
               standalone
+              name="resolutionDate"
               :validation-context="addResolutionDateValidationContext"
             />
           </div>
@@ -465,7 +466,7 @@ watch(requiresResolutionDate, (v) => {
           :label-overrides="tableLabels"
           :allowed-actions="tableAllowedActions"
           :prevent-actions="shouldPreventActions"
-          :hide-actions-when="() => variant === 'readonly' || variant === 'correct-readonly'"
+          :hide-actions-when="() => isReadOnly"
           :task-guard-config="{
             messageId: resolutionDateAlertMessageId,
             targetId: resolutionDateAlertTargetId,
@@ -481,6 +482,7 @@ watch(requiresResolutionDate, (v) => {
               v-if="activeResolutionDate"
               v-model="activeResolutionDate"
               :state-key
+              name="activeResolutionDate"
               :validation-context="changeResolutionDateValidationContext"
               :variant="variant === 'correct' ? 'correct' : (row.original.old ? 'change' : 'edit')"
               @done="() => updateResolutionDate(row, activeResolutionDate, cleanupForm)"

--- a/packages/layers/base/app/components/ManageShareStructure/index.vue
+++ b/packages/layers/base/app/components/ManageShareStructure/index.vue
@@ -78,8 +78,10 @@ watch(() => props.actionPreventedSignal, (value) => {
   }
 })
 
+const isReadOnly = computed(() => props.variant === 'readonly' || props.variant === 'correct-readonly')
+
 const showAddButton = computed(() => {
-  if (props.variant === 'readonly' || props.variant === 'correct-readonly') {
+  if (isReadOnly.value) {
     return false
   }
   return !props.allowedActions || props.allowedActions.includes(ManageAllowedAction.ADD)
@@ -99,7 +101,7 @@ const tableAllowedActions = computed(() => {
   if (props.allowedActions) {
     return props.allowedActions
   }
-  if (props.variant === 'readonly' || props.variant === 'correct-readonly') {
+  if (isReadOnly.value) {
     return []
   }
   return undefined
@@ -199,7 +201,7 @@ function onInitEdit(row: TableBusinessRow<ShareClassSchema | ShareSeriesSchema>)
 }
 
 function hideRowActionsWhen(row: TableBusinessRow<ShareClassSchema>) {
-  if (props.variant === 'readonly' || props.variant === 'correct-readonly') {
+  if (isReadOnly.value) {
     return true
   }
 
@@ -274,6 +276,7 @@ const hasRightsOrRestrictions = computed(() => shareClasses.value.some((c) => {
 
 const requiresResolutionDate = computed(() => hasChangedShares.value
   && hasRightsOrRestrictions.value
+  && !isReadOnly.value
   && props.collectResolutionDate
 )
 const existingResolutionDates = computed(() => resolutionDates.value.map(rd => rd.new))

--- a/packages/layers/base/app/components/Table/Business/index.vue
+++ b/packages/layers/base/app/components/Table/Business/index.vue
@@ -52,7 +52,7 @@ const tableUi = computed(() => {
   const tr = [
     '[&:has([data-is-editing="true"])]:hidden',
     /* eslint-disable-next-line max-len */
-    "relative after:absolute after:content-[''] after:bottom-0 last:after:hidden data-[expanded=true]:after:hidden after:h-px after:bg-gray-200",
+    "relative after:absolute after:content-[''] after:bottom-0 after:h-px after:bg-gray-200 last:after:hidden data-[expanded=true]:after:hidden",
     props.trDividerFullWidth
       ? 'after:left-0 after:right-0'
       : 'after:left-6 after:right-6'

--- a/packages/layers/base/app/components/Table/Business/index.vue
+++ b/packages/layers/base/app/components/Table/Business/index.vue
@@ -118,8 +118,8 @@ const tableUi = computed(() => {
       <tr
         :class="!(props.hideEmptyText && props.hideTableHeader)
           && [
-          `relative after:absolute after:content-['']`,
-          'after:bottom-0 after:left-6 after:right-6 after:h-px after:bg-gray-200'
+            `relative after:absolute after:content-['']`,
+            'after:bottom-0 after:left-6 after:right-6 after:h-px after:bg-gray-200'
           ]
         "
       >

--- a/packages/layers/base/app/components/Table/Business/index.vue
+++ b/packages/layers/base/app/components/Table/Business/index.vue
@@ -52,7 +52,7 @@ const tableUi = computed(() => {
   const tr = [
     '[&:has([data-is-editing="true"])]:hidden',
     /* eslint-disable-next-line max-len */
-    "relative after:absolute after:content-[''] after:bottom-0 after:h-px after:bg-gray-200 last:after:hidden data-[expanded=true]:after:hidden",
+    "relative after:absolute after:content-[''] after:bottom-0 last:after:hidden data-[expanded=true]:after:hidden after:h-px after:bg-gray-200",
     props.trDividerFullWidth
       ? 'after:left-0 after:right-0'
       : 'after:left-6 after:right-6'
@@ -116,10 +116,12 @@ const tableUi = computed(() => {
 
     <template v-if="showBodyTopSlot" #body-top>
       <tr
-        :class="[
+        :class="!(props.hideEmptyText && props.hideTableHeader)
+          && [
           `relative after:absolute after:content-['']`,
           'after:bottom-0 after:left-6 after:right-6 after:h-px after:bg-gray-200'
-        ]"
+          ]
+        "
       >
         <td :colspan="columns.length">
           <div

--- a/packages/layers/base/app/components/Table/ShareStructure/ResolutionDates/index.vue
+++ b/packages/layers/base/app/components/Table/ShareStructure/ResolutionDates/index.vue
@@ -4,7 +4,6 @@ import type { ExpandedState } from '@tanstack/vue-table'
 const props = defineProps<{
   data?: TableBusinessState<T>[]
   loading?: boolean
-  emptyText?: string
   allowedActions?: ManageAllowedAction[]
   preventActions?: boolean
   labelOverrides?: TableLabelOverrides
@@ -34,7 +33,6 @@ defineOptions({
       v-model:expanded="expanded"
       :data="displayedData"
       :loading
-      :empty-text
       :columns
       :allowed-actions="allowedActions"
       :prevent-actions="preventActions"
@@ -42,6 +40,7 @@ defineOptions({
       :get-row-id="(row: TableBusinessState<T>) => row.new.id"
       :hide-actions-when
       hide-table-header
+      hide-empty-text
       tr-divider-full-width
     >
       <template #expanded="{ row }">
@@ -56,7 +55,7 @@ defineOptions({
         :label="showAll ? $t('label.showLess') : $t('label.showAll')"
         variant="link"
         class="w-min underline p-0"
-        @click="showAll = !showAll"
+        @click="() => { showAll = !showAll }"
       />
     </div>
   </div>

--- a/packages/layers/base/app/interfaces/resolution.ts
+++ b/packages/layers/base/app/interfaces/resolution.ts
@@ -1,7 +1,7 @@
 export interface Resolution {
   date: string
-  id: number
-  type: string
+  id?: number // may be undefined when loading a draft
+  type?: string // may be undefined when loading a draft
   signatory?: Person
   signingDate?: string
 }

--- a/packages/layers/base/app/utils/format-resolution-dates.ts
+++ b/packages/layers/base/app/utils/format-resolution-dates.ts
@@ -18,10 +18,23 @@ export function formatResolutionDatesApi(
 
 export function formatResolutionDatesSection(
   originalDates: Resolution[],
-  draftDates: Resolution[] = []
+  draftDates?: Resolution[]
 ): { newState: ResolutionDateSchema, tableState: TableBusinessState<ResolutionDateSchema>[] } {
   const schema = getResolutionDateSchema()
   let newState: ResolutionDateSchema = schema.parse({})
+
+  // if no draft state exists, do not modify the table state
+  if (draftDates === undefined) {
+    const tableState: TableBusinessState<ResolutionDateSchema>[] = originalDates.map((date) => {
+      const parsed = schema.parse(date)
+      return {
+        old: structuredClone(parsed),
+        new: structuredClone(parsed)
+      }
+    })
+
+    return { newState, tableState }
+  }
 
   const drafts: Resolution[] = []
 

--- a/packages/layers/base/app/utils/format-resolution-dates.ts
+++ b/packages/layers/base/app/utils/format-resolution-dates.ts
@@ -25,7 +25,7 @@ export function formatResolutionDatesSection(
 
   const drafts: Resolution[] = []
 
-  draftDates.forEach(d => {
+  draftDates.forEach((d) => {
     if (d.id === undefined) {
       newState = schema.parse({ ...d, actions: [ActionType.ADDED] })
     } else {
@@ -35,7 +35,7 @@ export function formatResolutionDatesSection(
 
   const tableState: TableBusinessState<ResolutionDateSchema>[] = originalDates.map((date) => {
     const oldParsed = schema.parse(date)
-    const matchingDraft = drafts.find((d) => d.id === date.id)
+    const matchingDraft = drafts.find(d => d.id === date.id)
 
     if (matchingDraft) {
       const newParsed = schema.parse(matchingDraft)

--- a/packages/layers/base/app/utils/format-resolution-dates.ts
+++ b/packages/layers/base/app/utils/format-resolution-dates.ts
@@ -1,10 +1,63 @@
-export function formatResolutionDatesUi(dates: Resolution[]): Array<{
-  old: ResolutionDateSchema
-  new: ResolutionDateSchema
-}> {
+export function formatResolutionDatesApi(
+  dates: TableBusinessState<ResolutionDateSchema>[]
+): Resolution[] | undefined {
+  const changedDates = dates
+    .filter(d => !d.new.actions.includes(ActionType.REMOVED))
+    .map((d) => {
+      const isNewDate = d.old === undefined
+
+      return {
+        id: isNewDate ? undefined : parseInt(d.new.id),
+        type: d.new.type,
+        date: d.new.date
+      }
+    })
+
+  return changedDates.length > 0 ? changedDates : undefined
+}
+
+export function formatResolutionDatesSection(
+  originalDates: Resolution[],
+  draftDates: Resolution[] = []
+): { newState: ResolutionDateSchema, tableState: TableBusinessState<ResolutionDateSchema>[] } {
   const schema = getResolutionDateSchema()
-  return dates.map((d) => {
-    const data = schema.parse(d)
-    return { old: structuredClone(data), new: structuredClone(data) }
+  let newState: ResolutionDateSchema = schema.parse({})
+
+  const drafts: Resolution[] = []
+
+  draftDates.forEach(d => {
+    if (d.id === undefined) {
+      newState = schema.parse({ ...d, actions: [ActionType.ADDED] })
+    } else {
+      drafts.push(d)
+    }
   })
+
+  const tableState: TableBusinessState<ResolutionDateSchema>[] = originalDates.map((date) => {
+    const oldParsed = schema.parse(date)
+    const matchingDraft = drafts.find((d) => d.id === date.id)
+
+    if (matchingDraft) {
+      const newParsed = schema.parse(matchingDraft)
+      const isChanged = oldParsed.date !== newParsed.date
+
+      return {
+        old: oldParsed,
+        new: {
+          ...newParsed,
+          actions: isChanged ? [ActionType.CHANGED] : []
+        }
+      }
+    }
+
+    return {
+      old: oldParsed,
+      new: {
+        ...oldParsed,
+        actions: [ActionType.REMOVED]
+      }
+    }
+  })
+
+  return { newState, tableState }
 }

--- a/packages/layers/base/app/utils/format-resolution-dates.ts
+++ b/packages/layers/base/app/utils/format-resolution-dates.ts
@@ -1,0 +1,10 @@
+export function formatResolutionDatesUi(dates: Resolution[]): Array<{
+  old: ResolutionDateSchema
+  new: ResolutionDateSchema
+}> {
+  const schema = getResolutionDateSchema()
+  return dates.map((d) => {
+    const data = schema.parse(d)
+    return { old: structuredClone(data), new: structuredClone(data) }
+  })
+}

--- a/packages/layers/base/tests/unit/utils/format-resolution-dates.spec.ts
+++ b/packages/layers/base/tests/unit/utils/format-resolution-dates.spec.ts
@@ -124,4 +124,14 @@ describe('formatResolutionDatesSection', () => {
     expect(tableState[0]!.new.date).toBe('2026-01-01')
     expect(tableState[0]!.new.actions).toEqual([])
   })
+
+  it('should not modify original dates when draftDates is undefined', () => {
+    const originalDates = [{ id: 10, type: 'TYPE_A', date: '2026-01-01' }]
+
+    const { tableState } = formatResolutionDatesSection(originalDates, undefined)
+
+    expect(tableState).toHaveLength(1)
+    expect(tableState[0]!.old).toEqual(tableState[0]!.new)
+    expect(tableState[0]!.new.actions).toEqual([])
+  })
 })

--- a/packages/layers/base/tests/unit/utils/format-resolution-dates.spec.ts
+++ b/packages/layers/base/tests/unit/utils/format-resolution-dates.spec.ts
@@ -124,4 +124,4 @@ describe('formatResolutionDatesSection', () => {
     expect(tableState[0]!.new.date).toBe('2026-01-01')
     expect(tableState[0]!.new.actions).toEqual([])
   })
-}) 
+})

--- a/packages/layers/base/tests/unit/utils/format-resolution-dates.spec.ts
+++ b/packages/layers/base/tests/unit/utils/format-resolution-dates.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+
+describe('formatResolutionDatesApi', () => {
+  it('should return undefined when given an empty array', () => {
+    const result = formatResolutionDatesApi([])
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should filter out items with REMOVED action', () => {
+    const mockData = [
+      {
+        old: { id: '1', type: 'SPECIAL', date: '2026-01-01', actions: [], isEditing: false },
+        new: { id: '1', type: 'SPECIAL', date: '2026-01-01', actions: [ActionType.REMOVED], isEditing: false }
+      }
+    ]
+
+    const result = formatResolutionDatesApi(mockData)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should map table state to API format', () => {
+    const mockData = [
+      {
+        old: { id: '42', type: 'SPECIAL', date: '2026-05-10', actions: [], isEditing: false },
+        new: { id: '42', type: 'SPECIAL', date: '2026-05-12', actions: [ActionType.CHANGED], isEditing: false }
+      }
+    ]
+
+    const result = formatResolutionDatesApi(mockData)
+
+    expect(result).toHaveLength(1)
+    expect(result![0]!.id).toBe(42)
+    expect(result![0]!.type).toBe('SPECIAL')
+    expect(result![0]!.date).toBe('2026-05-12')
+  })
+
+  it('should set id to undefined for a newly added date', () => {
+    const mockData = [
+      {
+        old: undefined,
+        new: { id: '99', date: '2026-06-01', actions: [ActionType.ADDED], isEditing: false }
+      }
+    ]
+
+    const result = formatResolutionDatesApi(mockData)
+
+    expect(result![0]!.id).toBeUndefined()
+    expect(result![0]!.date).toBe('2026-06-01')
+  })
+
+  it('should filter removed dates', () => {
+    const mockData = [
+      {
+        old: { id: '1', type: 'A', date: '2026-01-01', actions: [], isEditing: false },
+        new: { id: '1', type: 'A', date: '2026-01-01', actions: [], isEditing: false }
+      },
+      {
+        old: { id: '2', type: 'B', date: '2026-02-01', actions: [], isEditing: false },
+        new: { id: '2', type: 'B', date: '2026-02-02', actions: [ActionType.CHANGED], isEditing: false }
+      },
+      {
+        old: { id: '3', type: 'C', date: '2026-03-01', actions: [], isEditing: false },
+        new: { id: '3', type: 'C', date: '2026-03-01', actions: [ActionType.REMOVED], isEditing: false }
+      }
+    ]
+
+    const result = formatResolutionDatesApi(mockData)
+
+    expect(result).toHaveLength(2)
+    expect(result![0]!.id).toBe(1)
+    expect(result![1]!.id).toBe(2)
+  })
+})
+
+describe('formatResolutionDatesSection', () => {
+  it('should handle empty original and draft dates', () => {
+    const { newState, tableState } = formatResolutionDatesSection([])
+
+    expect(tableState).toHaveLength(0)
+    expect(newState).toBeDefined()
+  })
+
+  it('should add ADDED action to newState when draft item has no id', () => {
+    const draftDates = [{ id: undefined, type: 'NEW_TYPE', date: '2026-07-01' }]
+
+    const { newState } = formatResolutionDatesSection([], draftDates)
+
+    expect(newState.type).toBe('NEW_TYPE')
+    expect(newState.date).toBe('2026-07-01')
+    expect(newState.actions).toEqual([ActionType.ADDED])
+  })
+
+  it('should add REMOVED action if original date is missing in draftDates', () => {
+    const originalDates = [{ id: 10, type: 'TYPE_A', date: '2026-01-01' }]
+
+    const { tableState } = formatResolutionDatesSection(originalDates, [])
+
+    expect(tableState).toHaveLength(1)
+    expect(tableState[0]!).toHaveProperty('old')
+    expect(tableState[0]!).toHaveProperty('new')
+
+    expect(tableState[0]!.old!.id).toBe('10')
+    expect(tableState[0]!.new.actions).toEqual([ActionType.REMOVED])
+  })
+
+  it('should add CHANGED action when draft date differs from original date', () => {
+    const originalDates = [{ id: 10, type: 'TYPE_A', date: '2026-01-01' }]
+    const draftDates = [{ id: 10, type: 'TYPE_A', date: '2026-01-05' }]
+
+    const { tableState } = formatResolutionDatesSection(originalDates, draftDates)
+
+    expect(tableState[0]!.new.date).toBe('2026-01-05')
+    expect(tableState[0]!.new.actions).toEqual([ActionType.CHANGED])
+  })
+
+  it('should keep actions empty when draft date matches original date', () => {
+    const originalDates = [{ id: 10, type: 'TYPE_A', date: '2026-01-01' }]
+    const draftDates = [{ id: 10, type: 'TYPE_A', date: '2026-01-01' }]
+
+    const { tableState } = formatResolutionDatesSection(originalDates, draftDates)
+
+    expect(tableState[0]!.new.date).toBe('2026-01-01')
+    expect(tableState[0]!.new.actions).toEqual([])
+  })
+}) 

--- a/web/corps/app/components/Form/Correction/Step1.vue
+++ b/web/corps/app/components/Form/Correction/Step1.vue
@@ -116,6 +116,7 @@ function onActionPrevented() {
       :prevent-actions="hasActiveSubForm"
       variant="correct"
       :action-prevented-signal="actionPreventedSignal"
+      :collect-resolution-date="store.requireResolutionDate"
       @action-prevented="onActionPrevented"
     />
   </UForm>

--- a/web/corps/app/components/Form/Correction/Step1.vue
+++ b/web/corps/app/components/Form/Correction/Step1.vue
@@ -108,6 +108,8 @@ function onActionPrevented() {
     <ManageShareStructure
       v-model:active-class="store.formState.activeClass"
       v-model:active-series="store.formState.activeSeries"
+      v-model:active-rd="store.formState.activeResolutionDate"
+      v-model:rd="store.formState.resolutionDate"
       data-testid="share-structure-section"
       :loading="store.initializing"
       :empty-text="$t('label.noSubjectAddedYet', { subject: $t('label.shareClasses') })"

--- a/web/corps/app/components/Form/Correction/Step2.vue
+++ b/web/corps/app/components/Form/Correction/Step2.vue
@@ -141,6 +141,7 @@ function onError(event: FormErrorEvent) {
         :loading="store.initializing"
         :empty-text="$t('label.noShareClasses')"
         variant="correct-readonly"
+        :collect-resolution-date="store.requireResolutionDate"
       />
     </section>
 

--- a/web/corps/app/components/Form/Correction/Step2.vue
+++ b/web/corps/app/components/Form/Correction/Step2.vue
@@ -33,6 +33,7 @@ const hasDirectorChanges = computed(() => {
 /** Whether any share classes were changed */
 const hasShareStructureChanges = computed(() => {
   return store.shareClasses.some(sc => sc.new.actions.length > 0)
+    || store.resolutionDates.some(rd => rd.new.actions.length > 0)
 })
 
 /** Whether any receivers were changed */

--- a/web/corps/app/components/Form/Transition/Step1.vue
+++ b/web/corps/app/components/Form/Transition/Step1.vue
@@ -102,6 +102,7 @@ defineExpose({
       :empty-text="$t('label.noSubjectAddedYet', { subject: $t('label.shareClasses') })"
       :section-title="`3. ${$t('label.shareStructure')}`"
       :section-description="$t('text.shareStructureMustMatchCompanysCurrentState')"
+      :collect-resolution-date="false"
     />
   </UForm>
 </template>

--- a/web/corps/app/interfaces/correction.ts
+++ b/web/corps/app/interfaces/correction.ts
@@ -72,7 +72,7 @@ export interface CorrectionPayload extends FilingPayloadData {
   // UI submits with `actions` (plural) array — using flexible type for both directions
   shareStructure?: {
     shareClasses: Array<ShareClass & { action?: string, actions?: ActionType[] }>
-    resolutionDates?: string[]
+    resolutionDates?: Resolution[]
   }
 
   // TODO: add additional correction-specific fields as needed

--- a/web/corps/app/pages/correction/[businessId]/[filingId].vue
+++ b/web/corps/app/pages/correction/[businessId]/[filingId].vue
@@ -3,13 +3,6 @@ const { t } = useI18n()
 const store = useCorrectionStore()
 const { initializing } = storeToRefs(store)
 const route = useRoute()
-const { setAlert: setPartiesAlert } = useFilingAlerts('manage-parties')
-const { setAlert: setOfficesAlert } = useFilingAlerts('manage-offices')
-const { setAlert: setReceiversAlert } = useFilingAlerts('manage-receivers')
-const { setAlert: setLiquidatorsAlert } = useFilingAlerts('manage-liquidators')
-const { setAlert: setSharesAlert } = useFilingAlerts('manage-share-structure')
-const { setAlert: setNameTranslationsAlert } = useFilingAlerts('manage-name-translations')
-const { setAlert: setCompanyNameAlert } = useFilingAlerts('manage-company-name')
 const { breadcrumbs, dashboardUrl } = useFilingNavigation(t('page.correction.h1'))
 const modal = useFilingModals()
 const { handleButtonLoading, setAlertText: setBtnCtrlAlert } = useConnectButtonControl()
@@ -34,19 +27,18 @@ const {
     [() => store.initialOffices, () => store.offices],
     [() => store.initialShareClasses, () => store.shareClasses],
     [() => store.initialNameTranslations, () => store.nameTranslations],
-    [() => store.companyName.old.legalName, () => store.companyName.new.legalName]
+    [() => store.companyName.old.legalName, () => store.companyName.new.legalName],
+    [() => store.initialResolutionDates, () => store.resolutionDates]
   ],
   // At least one correctable section must have changes to allow submission
   () => {
-    const hasValidComment = !!store.formState.comment?.detail?.trim()
-
     return store.directors.some(d => d.new.actions.length > 0)
       || store.receivers.some(r => r.new.actions.length > 0)
       || store.liquidators.some(l => l.new.actions.length > 0)
       || store.offices.some(o => o.new.actions?.length > 0)
       || store.shareClasses.some(sc => sc.new.actions.length > 0)
+      || store.resolutionDates.some(rd => rd.new.actions.length > 0)
       || store.nameTranslations.some(nt => nt.new.actions.length > 0)
-      || (store.hasCommentChanges && hasValidComment)
       || store.companyName.new.actions.length > 0
   }
 )
@@ -76,24 +68,9 @@ const originalFilingDate = computed(() => {
   return toReadableDate(store.correctedFilingDate)
 })
 
-function checkActiveSubForm() {
-  if (!store.hasActiveSubForm) {
-    return false
-  }
-  const alertMsg = t('text.finishTaskBeforeOtherChanges')
-  return (store.formState.activeOffice && setOfficesAlert('office-address-form', alertMsg))
-    || (store.formState.activeDirector && setPartiesAlert('party-details-form', alertMsg))
-    || (store.formState.activeReceiver && setReceiversAlert('party-details-form', alertMsg))
-    || (store.formState.activeLiquidator && setLiquidatorsAlert('party-details-form', alertMsg))
-    || (store.formState.activeClass && setSharesAlert('share-class-form', alertMsg))
-    || (store.formState.activeSeries && setSharesAlert('share-series-form', alertMsg))
-    || (store.formState.activeNameTranslation && setNameTranslationsAlert('name-translation-form', alertMsg))
-    || (store.formState.activeNameRequest && setCompanyNameAlert('company-name-form', alertMsg))
-}
-
 function reviewAndConfirm() {
   setBtnCtrlAlert(undefined)
-  if (checkActiveSubForm()) {
+  if (store.hasActiveSubForm) {
     return
   }
   if (!canSubmit()) {
@@ -105,7 +82,7 @@ function reviewAndConfirm() {
 async function submitFiling() {
   try {
     setBtnCtrlAlert(undefined)
-    if (checkActiveSubForm()) {
+    if (store.hasActiveSubForm) {
       return
     }
     if (!canSubmit()) {
@@ -126,7 +103,7 @@ async function saveFiling(resumeLater = false, enableUnsavedChangesBlock = true)
   try {
     if (enableUnsavedChangesBlock) {
       setBtnCtrlAlert(undefined)
-      if (checkActiveSubForm()) {
+      if (store.hasActiveSubForm) {
         return
       }
       if (!canSave()) {
@@ -182,6 +159,10 @@ const { currentStep, nextStep } = useFilingPageWatcher({
   ],
   buttonLayout: 'stackedDefault'
 })
+
+watch(currentStep, (step) => {
+  store.syncResolutionTableState(step === 2)
+}, { immediate: true })
 </script>
 
 <template>

--- a/web/corps/app/stores/correction.ts
+++ b/web/corps/app/stores/correction.ts
@@ -43,6 +43,7 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     || !!formState.activeLiquidator
     || !!formState.activeClass
     || !!formState.activeSeries
+    || !!formState.activeResolutionDate
   )
 
   const hasCommentChanges = computed(() => {
@@ -427,6 +428,7 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     formState.activeClass = undefined
     formState.activeSeries = undefined
     formState.activeNameTranslation = undefined
+    formState.activeResolutionDate = undefined
 
     tableNameTranslations.value = []
 

--- a/web/corps/app/stores/correction.ts
+++ b/web/corps/app/stores/correction.ts
@@ -86,8 +86,8 @@ export const useCorrectionStore = defineStore('correction-store', () => {
    * @param draftId - The pre-created correction draft filing ID (from route param `filingId`)
    */
   async function init(businessId: string, draftId?: string) {
-    initializing.value = true
     $reset()
+    initializing.value = true
 
     const { draftFiling, parties: allParties, addresses, shareClasses } = await initFiling<CorrectionFiling>(
       businessId,
@@ -477,6 +477,9 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     initialShareClasses.value = []
     initialNameTranslations.value = []
     initialResolutionDates.value = []
+
+    initializing.value = false
+    requireResolutionDate.value = false
   }
 
   return {

--- a/web/corps/app/stores/correction.ts
+++ b/web/corps/app/stores/correction.ts
@@ -6,7 +6,7 @@ export const useCorrectionStore = defineStore('correction-store', () => {
   const { tableState: tableReceivers } = useManageParties('manage-receivers')
   const { tableState: tableLiquidators } = useManageParties('manage-liquidators')
   const { tableState: tableOffices } = useManageOffices()
-  const { shareClasses: tableShareClasses } = useManageShareStructure()
+  const { shareClasses: tableShareClasses, resolutionDates } = useManageShareStructure()
   const { tableState: tableNameTranslations } = useManageNameTranslations('manage-company-name-name-translations')
   const { state: companyName, hasNameChange, updateState: updateCompanyName } = useManageCompanyName()
   const { formatAddressTableState, formatDraftTableState } = useBusinessAddresses()
@@ -105,50 +105,54 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     )
     const aliasesNameTranslations = await service.getNameTranslations(businessId).catch(() => [] as NameTranslation[])
 
+    // The draft is always expected to exist (pre-created before page load)
+    const draft = draftFiling!.filing.correction
+    draftFilingState.value = draftFiling!
+
+    // Correction metadata from the pre-created draft
+    correctedFilingId.value = draft.correctedFilingId
+    correctedFilingType.value = draft.correctedFilingType
+    correctedFilingDate.value = draft.correctedFilingDate ?? ''
+    correctionType.value = draft.type
+
+    if (isResolutionFiling(correctedFilingType.value)) {
+      const resolutions = await service.getResolutions(businessId).catch(() => [])
+      resolutionDates.value = formatResolutionDatesUi(resolutions)
+      console.log('RESOLUTIONS: ', resolutionDates.value)
+    }
+
     // Filter the single parties response by role type (UI enum — data is already formatted)
     const parties = allParties?.filter(p => p.new.roles.some(r => r.roleType === RoleTypeUi.DIRECTOR))
     const receivers = allParties?.filter(p => p.new.roles.some(r => r.roleType === RoleTypeUi.RECEIVER))
     const liquidators = allParties?.filter(p => p.new.roles.some(r => r.roleType === RoleTypeUi.LIQUIDATOR))
 
-    // The draft is always expected to exist (pre-created before page load)
-    const draft = draftFiling?.filing?.correction
-    if (draft) {
-      draftFilingState.value = draftFiling
+    // Comment (may be empty on initial draft)
+    formState.comment = { detail: draft.comment ?? '' }
 
-      // Correction metadata from the pre-created draft
-      correctedFilingId.value = draft.correctedFilingId
-      correctedFilingType.value = draft.correctedFilingType
-      correctedFilingDate.value = draft.correctedFilingDate ?? ''
-      correctionType.value = draft.type
+    // Document delivery
+    if (formState.documentDelivery) {
+      formState.documentDelivery.completingPartyEmail = draft.contactPoint?.email ?? ''
+    }
 
-      // Comment (may be empty on initial draft)
-      formState.comment = { detail: draft.comment ?? '' }
+    // Header fields
+    const header = draftFiling!.filing.header
+    formState.staffPayment = formatStaffPaymentUi(header)
+    if (draft.courtOrder) {
+      formState.courtOrder = formatCourtOrderUi(draft.courtOrder)
+    }
 
-      // Document delivery
-      if (formState.documentDelivery) {
-        formState.documentDelivery.completingPartyEmail = draft.contactPoint?.email ?? ''
-      }
-
-      // Header fields
-      const header = draftFiling.filing.header
-      formState.staffPayment = formatStaffPaymentUi(header)
-      if (draft.courtOrder) {
-        formState.courtOrder = formatCourtOrderUi(draft.courtOrder)
-      }
-
-      // Completing party (client corrections only) — read from relationships (new format)
-      // The draft may contain multiple relationships with a "Completing Party" role:
-      // one from the original filing (e.g. an incorporator who was also the completing party)
-      // and one ADDED during this correction. We want the ADDED one.
-      const draftAllRelationships = draft?.relationships as BusinessRelationship[] | undefined
-      if (draftAllRelationships && formState.completingParty) {
-        const cpRelationship = draftAllRelationships.find(
-          r => r.roles?.some(role => role.roleType === RoleType.COMPLETING_PARTY)
-            && r.actions?.includes(ActionType.ADDED)
-        )
-        if (cpRelationship) {
-          Object.assign(formState.completingParty, formatCompletingPartyRelationshipUi(cpRelationship))
-        }
+    // Completing party (client corrections only) — read from relationships (new format)
+    // The draft may contain multiple relationships with a "Completing Party" role:
+    // one from the original filing (e.g. an incorporator who was also the completing party)
+    // and one ADDED during this correction. We want the ADDED one.
+    const draftAllRelationships = draft?.relationships as BusinessRelationship[] | undefined
+    if (draftAllRelationships && formState.completingParty) {
+      const cpRelationship = draftAllRelationships.find(
+        r => r.roles?.some(role => role.roleType === RoleType.COMPLETING_PARTY)
+          && r.actions?.includes(ActionType.ADDED)
+      )
+      if (cpRelationship) {
+        Object.assign(formState.completingParty, formatCompletingPartyRelationshipUi(cpRelationship))
       }
     }
 

--- a/web/corps/app/stores/correction.ts
+++ b/web/corps/app/stores/correction.ts
@@ -16,6 +16,7 @@ export const useCorrectionStore = defineStore('correction-store', () => {
 
   const initializing = ref<boolean>(false)
   const draftFilingState = shallowRef<CorrectionDraftState>({} as CorrectionDraftState)
+  const requireResolutionDate = ref(false)
 
   const formState = reactive<CorrectionFormSchema>({} as CorrectionFormSchema)
   const initialFormState = shallowRef<CorrectionFormSchema>({} as CorrectionFormSchema)
@@ -97,11 +98,17 @@ export const useCorrectionStore = defineStore('correction-store', () => {
       [OfficeType.RECORDS, OfficeType.REGISTERED],
       true // fetch share classes
     )
+
+    if (!draftFiling) {
+      initializing.value = false
+      return
+    }
+
     const aliasesNameTranslations = await service.getNameTranslations(businessId).catch(() => [] as NameTranslation[])
 
     // The draft is always expected to exist (pre-created before page load)
-    const draft = draftFiling!.filing.correction
-    draftFilingState.value = draftFiling!
+    const draft = draftFiling.filing.correction
+    draftFilingState.value = draftFiling
 
     // Correction metadata from the pre-created draft
     correctedFilingId.value = draft.correctedFilingId
@@ -222,7 +229,8 @@ export const useCorrectionStore = defineStore('correction-store', () => {
       }
     }
 
-    if (isResolutionFiling(correctedFilingType.value)) {
+    requireResolutionDate.value = isResolutionFiling(correctedFilingType.value)
+    if (requireResolutionDate.value) {
       const originalResolutions = await service.getResolutions(businessId).catch(() => [])
       const draftResolutions = draft.shareStructure?.resolutionDates
 
@@ -481,6 +489,7 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     correctedFilingDate,
     correctedFilingDateDisplay,
     correctionType,
+    requireResolutionDate,
     isStaffCorrectionType,
     directors: tableParties,
     receivers: tableReceivers,

--- a/web/corps/app/stores/correction.ts
+++ b/web/corps/app/stores/correction.ts
@@ -25,6 +25,7 @@ export const useCorrectionStore = defineStore('correction-store', () => {
   const initialOffices = shallowRef<TableBusinessState<OfficesSchema>[]>([])
   const initialShareClasses = shallowRef<TableBusinessState<ShareClassSchema>[]>([])
   const initialNameTranslations = shallowRef<TableBusinessState<NameTranslationSchema>[]>([])
+  const initialResolutionDates = shallowRef<TableBusinessState<ResolutionDateSchema>[]>([])
 
   const correctionComment = computed({
     get: () => formState.comment ?? { detail: '' },
@@ -45,13 +46,6 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     || !!formState.activeSeries
     || !!formState.activeResolutionDate
   )
-
-  const hasCommentChanges = computed(() => {
-    const initialComment = initialFormState.value.comment?.detail?.trim() ?? ''
-    const currentComment = formState.comment?.detail?.trim() ?? ''
-
-    return currentComment !== initialComment
-  })
 
   /** The original filing being corrected (fetched by correctedFilingId) */
   const correctedFiling = shallowRef<FilingGetByIdResponse<FilingRecord> | undefined>(undefined)
@@ -118,7 +112,6 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     if (isResolutionFiling(correctedFilingType.value)) {
       const resolutions = await service.getResolutions(businessId).catch(() => [])
       resolutionDates.value = formatResolutionDatesUi(resolutions)
-      console.log('RESOLUTIONS: ', resolutionDates.value)
     }
 
     // Filter the single parties response by role type (UI enum — data is already formatted)
@@ -289,6 +282,7 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     initialOffices.value = cloneDeep(tableOffices.value)
     initialShareClasses.value = cloneDeep(tableShareClasses.value)
     initialNameTranslations.value = cloneDeep(tableNameTranslations.value)
+    initialResolutionDates.value = cloneDeep(resolutionDates.value)
 
     // Fee: STAFF type corrections = no fee, CLIENT type corrections = $20 (CRCTN fee code)
     if (isStaffCorrectionType.value) {
@@ -416,6 +410,27 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     }
   }
 
+  function syncResolutionTableState(isReview: boolean) {
+    const addedDate = formState.resolutionDate
+
+    if (!isReview) {
+      resolutionDates.value = cloneDeep(initialResolutionDates.value)
+      return
+    }
+
+    if (!addedDate) {
+      return
+    }
+
+    const existingIndex = resolutionDates.value.findIndex(rd => rd.new.id === addedDate.id)
+
+    if (existingIndex > -1) {
+      resolutionDates.value[existingIndex] = { old: undefined, new: cloneDeep(addedDate) }
+    } else {
+      resolutionDates.value.unshift({ old: undefined, new: cloneDeep(addedDate) })
+    }
+  }
+
   function $reset() {
     correctedFilingId.value = undefined
     correctedFilingType.value = FilingType.UNKNOWN
@@ -443,6 +458,7 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     initialOffices.value = []
     initialShareClasses.value = []
     initialNameTranslations.value = []
+    initialResolutionDates.value = []
   }
 
   return {
@@ -461,6 +477,7 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     liquidators: tableLiquidators,
     offices: tableOffices,
     shareClasses: tableShareClasses,
+    resolutionDates,
     nameTranslations: tableNameTranslations,
     initialFormState,
     initialDirectors,
@@ -468,13 +485,14 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     initialLiquidators,
     initialOffices,
     initialShareClasses,
+    initialResolutionDates,
     initialNameTranslations,
     hasActiveSubForm,
-    hasCommentChanges,
     isStaff,
     companyName,
     init,
     submit,
+    syncResolutionTableState,
     $reset
   }
 })

--- a/web/corps/app/stores/correction.ts
+++ b/web/corps/app/stores/correction.ts
@@ -109,11 +109,6 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     correctedFilingDate.value = draft.correctedFilingDate ?? ''
     correctionType.value = draft.type
 
-    if (isResolutionFiling(correctedFilingType.value)) {
-      const resolutions = await service.getResolutions(businessId).catch(() => [])
-      resolutionDates.value = formatResolutionDatesUi(resolutions)
-    }
-
     // Filter the single parties response by role type (UI enum — data is already formatted)
     const parties = allParties?.filter(p => p.new.roles.some(r => r.roleType === RoleTypeUi.DIRECTOR))
     const receivers = allParties?.filter(p => p.new.roles.some(r => r.roleType === RoleTypeUi.RECEIVER))
@@ -227,6 +222,16 @@ export const useCorrectionStore = defineStore('correction-store', () => {
       }
     }
 
+    if (isResolutionFiling(correctedFilingType.value)) {
+      const originalResolutions = await service.getResolutions(businessId).catch(() => [])
+      const draftResolutions = draft.shareStructure?.resolutionDates
+
+      const { newState, tableState } = formatResolutionDatesSection(originalResolutions, draftResolutions)
+
+      formState.resolutionDate = cloneDeep(newState)
+      resolutionDates.value = cloneDeep(tableState)
+    }
+
     // Receivers — merge with draft relationships if applicable
     if (receivers) {
       const draftReceiverEntries = draftRelationships?.filter(
@@ -331,7 +336,8 @@ export const useCorrectionStore = defineStore('correction-store', () => {
 
       // Share structure
       shareStructure: {
-        shareClasses: formatShareClassesApi(tableShareClasses.value, isSubmission)
+        shareClasses: formatShareClassesApi(tableShareClasses.value, isSubmission),
+        resolutionDates: formatResolutionDatesApi(resolutionDates.value)
       },
 
       // Court order (common filing data)
@@ -414,7 +420,11 @@ export const useCorrectionStore = defineStore('correction-store', () => {
     const addedDate = formState.resolutionDate
 
     if (!isReview) {
-      resolutionDates.value = cloneDeep(initialResolutionDates.value)
+      if (addedDate?.id) {
+        resolutionDates.value = resolutionDates.value.filter(
+          rd => rd.new.id !== addedDate.id
+        )
+      }
       return
     }
 

--- a/web/corps/app/utils/correction/index.ts
+++ b/web/corps/app/utils/correction/index.ts
@@ -1,1 +1,2 @@
 export * from './correct-name-options'
+export * from './is-resolution-filing'

--- a/web/corps/app/utils/correction/is-resolution-filing.ts
+++ b/web/corps/app/utils/correction/is-resolution-filing.ts
@@ -1,0 +1,17 @@
+// These filings do not require a resolution date to alter the share structure
+export const NO_RESOLUTION_FILING_TYPES = [
+  FilingType.AMALGAMATION_APPLICATION,
+  FilingType.AMALGAMATION_OUT,
+  FilingType.ANNUAL_REPORT,
+  FilingType.CONSENT_AMALGAMATION_OUT,
+  FilingType.CONSENT_CONTINUATION_OUT,
+  FilingType.CONTINUATION_IN,
+  FilingType.CONTINUATION_OUT,
+  FilingType.CHANGE_OF_DIRECTORS,
+  FilingType.INCORPORATION_APPLICATION,
+  FilingType.TRANSITION
+]
+
+export function isResolutionFiling(filingType: FilingType): boolean {
+  return !NO_RESOLUTION_FILING_TYPES.includes(filingType)
+}

--- a/web/corps/app/utils/schemas/correction.ts
+++ b/web/corps/app/utils/schemas/correction.ts
@@ -55,7 +55,9 @@ export function getCorrectionSchema(isStaff: boolean) {
     activeClass: getActiveShareClassSchema(),
     activeSeries: getActiveShareSeriesSchema(),
     activeNameTranslation: getActiveNameTranslationSchema(),
-    activeNameRequest: getActiveNameRequestSchema()
+    activeNameRequest: getActiveNameRequestSchema(),
+    activeResolutionDate: getActiveResolutionDateSchema(),
+    resolutionDate: getActiveResolutionDateSchema()
   })
 
   if (isStaff) {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34275

*Description of changes:*
Base component:
- update readonly checks (new computed, different labels)
- props/interface updates to support draft response and apply correct styling
- base business table styling update


Transition:
- update ManageShareStructure usage to exclude resolution dates requirement

Correction:
- init resolution dates in filing when applicable (not all filings will have correctable resolution dates)
- save/load/draft state (This may need to be tweaked as the api is not ready yet)
- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-ui license (BSD 3-Clause).
